### PR TITLE
fix: post-reboot UI startup + headless Telegram boot reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+# Telegram credentials — never commit
+boot-report.env
+*.env

--- a/boot-report.env.example
+++ b/boot-report.env.example
@@ -1,23 +1,17 @@
-# boot-report.env — credentials cho Telegram boot reporter
-# Sao chép file này thành ~/.config/boot-report.env và điền thông tin:
+# boot-report.env — Telegram credentials cho boot reporter
 #
+# Sao chép thành ~/.config/boot-report.env rồi điền thông tin:
 #   cp ~/erisanh/boot-report.env.example ~/.config/boot-report.env
 #   nano ~/.config/boot-report.env
 #   chmod 600 ~/.config/boot-report.env
 #
+# Hoặc truyền qua env var khi chạy install.sh (khuyến nghị cho reinstall):
+#   TELEGRAM_BOT_TOKEN=xxx TELEGRAM_CHAT_ID=yyy bash install.sh
+#
 # Cách lấy thông tin:
-#
-# 1. Tạo bot: mở Telegram → tìm @BotFather → /newbot → đặt tên → lấy TOKEN
-#
-# 2. Lấy CHAT_ID:
-#    a. Gửi tin nhắn bất kỳ cho bot vừa tạo
-#    b. Mở trình duyệt, truy cập:
-#       https://api.telegram.org/bot<TOKEN>/getUpdates
-#    c. Tìm trường "id" trong "chat" → đó là CHAT_ID
-#
-# Ví dụ:
-#   TELEGRAM_BOT_TOKEN=7123456789:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-#   TELEGRAM_CHAT_ID=123456789
+#   Bot:     Telegram → @BotFather → /newbot → lấy token
+#   Chat ID: Gửi /start cho bot → mở https://api.telegram.org/bot<TOKEN>/getUpdates
+#            → tìm result[0].message.chat.id
 
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=

--- a/boot-report.env.example
+++ b/boot-report.env.example
@@ -1,0 +1,23 @@
+# boot-report.env — credentials cho Telegram boot reporter
+# Sao chép file này thành ~/.config/boot-report.env và điền thông tin:
+#
+#   cp ~/erisanh/boot-report.env.example ~/.config/boot-report.env
+#   nano ~/.config/boot-report.env
+#   chmod 600 ~/.config/boot-report.env
+#
+# Cách lấy thông tin:
+#
+# 1. Tạo bot: mở Telegram → tìm @BotFather → /newbot → đặt tên → lấy TOKEN
+#
+# 2. Lấy CHAT_ID:
+#    a. Gửi tin nhắn bất kỳ cho bot vừa tạo
+#    b. Mở trình duyệt, truy cập:
+#       https://api.telegram.org/bot<TOKEN>/getUpdates
+#    c. Tìm trường "id" trong "chat" → đó là CHAT_ID
+#
+# Ví dụ:
+#   TELEGRAM_BOT_TOKEN=7123456789:AAFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+#   TELEGRAM_CHAT_ID=123456789
+
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=

--- a/config/code/profiles/restore-profiles.sh
+++ b/config/code/profiles/restore-profiles.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Recreate VSCode profiles and install their extensions on a new machine (stable `code`).
 # Run: bash restore-profiles.sh   (requires `visual-studio-code-bin` installed)
+#
+# Fix (2026-06): VSCode --profile <name> fails with "Profile 'x' not found"
+# when running headless (no active Wayland/X11 session) because the profile
+# registry hasn't been written yet. Pre-seeding profiles.json solves this.
 set -euo pipefail
 
 CODE="${CODE_BIN:-code}"
@@ -11,17 +15,53 @@ if ! command -v "$CODE" >/dev/null 2>&1; then
   exit 1
 fi
 
+# ---- Pre-seed profiles.json so VSCode knows the profiles exist ----
+# Without this, --profile <name> fails with "Profile 'x' not found" during
+# headless first-boot provisioning (no display session active yet).
+PROFILES_SRC="$DIR/profiles.json"
+PROFILES_DEST="$HOME/.config/Code/User/profiles.json"
+if [ -f "$PROFILES_SRC" ]; then
+  mkdir -p "$HOME/.config/Code/User"
+  if [ ! -f "$PROFILES_DEST" ]; then
+    cp "$PROFILES_SRC" "$PROFILES_DEST"
+    echo "Pre-seeded $PROFILES_DEST from repo."
+  else
+    echo "(profiles.json already exists — keeping existing. Delete and re-run to reset.)"
+  fi
+fi
+
+# ---- Install extensions per profile ----
+FAILED_TOTAL=0
 for d in "$DIR"/*/; do
   name="$(basename "$d")"
   list="$d/extensions.txt"
   [ -f "$list" ] || { echo "== $name: no extensions.txt, skipping"; continue; }
   echo "== Profile: $name =="
-  # --profile <name> creates the profile if missing, then installs extensions into it
+
+  FAILED_EXTS=()
   while IFS= read -r ext; do
     [ -n "$ext" ] || continue
+    [[ "$ext" == \#* ]] && continue   # skip comment lines
     echo "  + $ext"
-    "$CODE" --profile "$name" --install-extension "$ext" --force >/dev/null || echo "    ! failed: $ext"
+    if "$CODE" --profile "$name" --install-extension "$ext" --force 2>/dev/null; then
+      : # success
+    else
+      echo "    ! failed: $ext"
+      FAILED_EXTS+=("$ext")
+      FAILED_TOTAL=$((FAILED_TOTAL + 1))
+    fi
   done < "$list"
+
+  if ((${#FAILED_EXTS[@]} > 0)); then
+    echo "  => ${#FAILED_EXTS[@]} extension(s) failed in '$name'."
+    echo "     Re-run after logging into Hyprland (display session required)."
+  fi
 done
 
-echo "Done. Open VSCode and pick a profile in the bottom-left. settings/keybindings use the shared default (symlinked)."
+echo ""
+if ((FAILED_TOTAL > 0)); then
+  echo "Done with $FAILED_TOTAL failure(s). Re-run after first Hyprland login."
+else
+  echo "Done. All extensions installed successfully."
+fi
+echo "Open VSCode and pick a profile in the bottom-left."

--- a/config/hypr/autostart.lua
+++ b/config/hypr/autostart.lua
@@ -39,16 +39,19 @@ hl.on("hyprland.start", function()
 	hl.exec_cmd("/usr/lib/polkit-kde-authentication-agent-1")
 	hl.exec_cmd("gnome-keyring-daemon --start --components=secrets")
 	hl.exec_cmd("fcitx5")
-	hl.exec_cmd("sleep 3 && quickshell")
+	-- Wait for graphical-session.target before launching quickshell so Qt/QML
+	-- services (weather, notifications) can reach the network on first boot.
+	-- Falls back to 5 s sleep if the target is not yet active.
+	hl.exec_cmd("bash -c 'systemctl --user is-active --quiet graphical-session.target || sleep 5; quickshell'")
 	hl.exec_cmd("hypridle")
 	hl.exec_cmd("hyprpaper")
 	hl.exec_cmd("hyprsunset")
 
 	-- App launches pinned to workspaces
-	-- TODO: verify exec_cmd rules syntax for workspace placement
-	hl.exec_cmd("zen-browser", { workspace = "1 silent" })
-	hl.exec_cmd("ghostty", { workspace = "2 silent" })
-	hl.exec_cmd("thunderbird", { workspace = "3 silent" })
+	-- Give quickshell bar 2 s to appear before launching workspace apps
+	hl.exec_cmd("sleep 2 && zen-browser", { workspace = "1 silent" })
+	hl.exec_cmd("sleep 2 && ghostty", { workspace = "2 silent" })
+	hl.exec_cmd("sleep 2 && thunderbird", { workspace = "3 silent" })
 
 	-- Helper scripts
 	hl.exec_cmd(shared.scripts_path .. "/zen_popup.sh")

--- a/config/hypr/scripts/boot-report.sh
+++ b/config/hypr/scripts/boot-report.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# boot-report.sh — gửi log boot/provision lên Telegram
+#
+# Chạy cuối quá trình `install.sh --firstboot` (hoặc --provision) để report
+# kết quả về remote ngay khi máy có mạng, không cần display/Hyprland.
+#
+# Cách dùng:
+#   bash boot-report.sh [--firstboot|--provision|--boot]
+#
+# Modes:
+#   --firstboot  : tóm tắt toàn bộ provision + các lỗi (default khi gọi từ install.sh)
+#   --provision  : như firstboot nhưng label "manual provision"
+#   --boot       : report systemd failed units sau mỗi lần reboot bình thường
+#                  (cài vào systemd user service nếu muốn monitor ongoing)
+#
+# Config: đọc từ ~/.config/boot-report.env (không commit lên git)
+#   TELEGRAM_BOT_TOKEN=123456:ABC...
+#   TELEGRAM_CHAT_ID=9876543
+#
+# Tạo bot: https://t.me/BotFather → /newbot
+# Lấy chat_id: gửi tin nhắn cho bot rồi truy cập
+#   https://api.telegram.org/bot<TOKEN>/getUpdates
+# ==============================================================================
+set -euo pipefail
+
+MODE="${1:---firstboot}"
+CONFIG_FILE="${HOME}/.config/boot-report.env"
+FIRSTBOOT_LOG="/var/log/dotfiles-firstboot.log"
+FAILED_PKG_FILE="${HOME}/.dotfiles-failed-packages.txt"
+HOSTNAME_STR="$(hostname)"
+TIMESTAMP="$(date '+%Y-%m-%d %H:%M:%S')"
+
+# ── Load credentials ──────────────────────────────────────────────────────────
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "boot-report: $CONFIG_FILE not found — skipping remote report." >&2
+  echo "Create it with:" >&2
+  echo "  echo 'TELEGRAM_BOT_TOKEN=xxx' >> $CONFIG_FILE" >&2
+  echo "  echo 'TELEGRAM_CHAT_ID=yyy'   >> $CONFIG_FILE" >&2
+  echo "  chmod 600 $CONFIG_FILE" >&2
+  exit 0
+fi
+# shellcheck source=/dev/null
+source "$CONFIG_FILE"
+
+if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+  echo "boot-report: TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID missing in $CONFIG_FILE" >&2
+  exit 0
+fi
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+tg_send() {
+  local text="$1"
+  # Telegram MarkdownV2 — escape special chars
+  curl -s -X POST \
+    "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -d chat_id="${TELEGRAM_CHAT_ID}" \
+    -d parse_mode="HTML" \
+    --data-urlencode "text=${text}" \
+    > /dev/null
+}
+
+tg_file() {
+  local caption="$1" filepath="$2"
+  [ -f "$filepath" ] || return 0
+  curl -s -X POST \
+    "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument" \
+    -F chat_id="${TELEGRAM_CHAT_ID}" \
+    -F caption="${caption}" \
+    -F document=@"${filepath}" \
+    > /dev/null
+}
+
+section() { printf '\n<b>%s</b>\n' "$1"; }
+
+# ── Collect info ──────────────────────────────────────────────────────────────
+collect_failed_units() {
+  systemctl --failed --no-legend --no-pager 2>/dev/null \
+    | awk '{print "  ● " $1}' | head -20 || echo "  (none)"
+}
+
+collect_failed_packages() {
+  if [ -f "$FAILED_PKG_FILE" ]; then
+    awk '{print "  ✗ " $0}' "$FAILED_PKG_FILE" | head -30
+  else
+    echo "  (none)"
+  fi
+}
+
+collect_journal_errors() {
+  # Last boot errors from journald (priority err and above), skip noisy lines
+  journalctl -b -p err --no-pager --no-hostname -q 2>/dev/null \
+    | grep -v -E "Failed to load.*theme|use-gl.*Electron|Bluetooth|hci|rfkill" \
+    | tail -30 \
+    | sed 's/^/  /' \
+    || echo "  (none or journald unavailable)"
+}
+
+collect_firstboot_errors() {
+  if [ -f "$FIRSTBOOT_LOG" ]; then
+    grep -i -E "error|fail|warn|✗|!" "$FIRSTBOOT_LOG" \
+      | grep -v "^$\|install.sh\|backup" \
+      | tail -40 \
+      | sed 's/^/  /' \
+      || echo "  (no errors found in log)"
+  else
+    echo "  (firstboot log not found)"
+  fi
+}
+
+uptime_str() { uptime -p 2>/dev/null || uptime; }
+kernel_str()  { uname -r; }
+disk_usage()  { df -h / 2>/dev/null | awk 'NR==2{print $3 " used / " $2 " total (" $5 ")"}'; }
+
+# ── Build message ─────────────────────────────────────────────────────────────
+build_message() {
+  local mode="$1"
+  local icon title
+
+  case "$mode" in
+    --firstboot) icon="🚀"; title="First-boot provision complete" ;;
+    --provision) icon="🔧"; title="Manual provision complete" ;;
+    --boot)      icon="⚡"; title="System boot report" ;;
+    *)           icon="📋"; title="Boot report" ;;
+  esac
+
+  local failed_units
+  failed_units="$(collect_failed_units)"
+
+  local status_icon="✅"
+  if echo "$failed_units" | grep -q "●"; then
+    status_icon="⚠️"
+  fi
+
+  cat <<MSG
+${status_icon} <b>${icon} ${title}</b>
+<b>Host:</b> ${HOSTNAME_STR}
+<b>Time:</b> ${TIMESTAMP}
+<b>Uptime:</b> $(uptime_str)
+<b>Kernel:</b> $(kernel_str)
+<b>Disk /:</b> $(disk_usage)
+$(section "❌ Failed systemd units")
+${failed_units}
+MSG
+
+  if [ "$mode" != "--boot" ]; then
+    cat <<MSG
+$(section "📦 Failed packages (yay)")
+$(collect_failed_packages)
+$(section "🔴 Provision errors (from log)")
+$(collect_firstboot_errors)
+MSG
+  fi
+
+  cat <<MSG
+$(section "🔴 Journal errors (this boot)")
+$(collect_journal_errors)
+MSG
+}
+
+# ── Send ──────────────────────────────────────────────────────────────────────
+MSG="$(build_message "$MODE")"
+
+# Telegram message limit is 4096 chars — truncate if needed
+if [ "${#MSG}" -gt 4000 ]; then
+  MSG="${MSG:0:3900}
+<i>... (truncated, see attached log)</i>"
+fi
+
+tg_send "$MSG"
+
+# Also attach full firstboot log if it exists and we're in provision mode
+if [ "$MODE" != "--boot" ] && [ -f "$FIRSTBOOT_LOG" ]; then
+  tg_file "📄 Full firstboot log — ${HOSTNAME_STR} ${TIMESTAMP}" "$FIRSTBOOT_LOG"
+fi
+
+echo "boot-report: sent to Telegram."

--- a/install.sh
+++ b/install.sh
@@ -410,6 +410,21 @@ ZRAM
     sudo rm -f /etc/systemd/system/dotfiles-firstboot.service
     sudo rm -f /etc/sudoers.d/99-dotfiles-install   # restore password-protected sudo
     info "first-boot service removed; passwordless sudo revoked."
+
+    # ---- 7. remote boot report (Telegram) ----
+    # Sends a summary of errors/failures to Telegram so you can debug
+    # a headless first-boot without needing to be at the machine.
+    # Requires ~/.config/boot-report.env with TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID.
+    # See config/hypr/scripts/boot-report.sh for setup instructions.
+    local REPORT_SCRIPT="$HOME/.config/hypr/scripts/boot-report.sh"
+    if [ -f "$REPORT_SCRIPT" ] && [ -f "$HOME/.config/boot-report.env" ]; then
+      log "Sending boot report to Telegram"
+      bash "$REPORT_SCRIPT" --firstboot || warn "boot-report failed (non-fatal)"
+    else
+      info "Skipping remote boot report (no ~/.config/boot-report.env found)."
+      info "To enable: create that file with TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID."
+      info "See: config/hypr/scripts/boot-report.sh"
+    fi
   fi
 
   log "All done."
@@ -419,6 +434,11 @@ Next steps (one-time):
   • Reboot to start SDDM / Hyprland and activate zram.
   • Set Brave as default browser and sign in to your apps.
   • GPU: desktop runs on the Intel iGPU (no NVIDIA driver installed by default).
+  • [Optional] Enable Telegram boot reports — run once after first login:
+      cp ~/erisanh/boot-report.env.example ~/.config/boot-report.env
+      nano ~/.config/boot-report.env   # điền BOT_TOKEN + CHAT_ID
+      chmod 600 ~/.config/boot-report.env
+    Hướng dẫn lấy token/chat_id: xem boot-report.env.example
 
 Replaced files (if any) were backed up to: $BACKUP
 EOF

--- a/install.sh
+++ b/install.sh
@@ -199,6 +199,12 @@ BOOTLOADER
 systemctl enable NetworkManager
 
 # arm Stage 2 to run automatically once the network is up after first boot
+# Write Telegram credentials into the service if provided at bootstrap time
+local TG_ENV_LINE=""
+if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+  TG_ENV_LINE="Environment=TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}\nEnvironment=TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}"
+fi
+
 cat > /etc/systemd/system/dotfiles-firstboot.service <<UNIT
 [Unit]
 Description=First-boot dotfiles provisioning (Stage 2 of install.sh)
@@ -209,6 +215,7 @@ After=network-online.target NetworkManager-wait-online.service
 Type=oneshot
 User=$USER_NAME
 Environment=HOME=/home/$USER_NAME
+$([ -n "$TG_ENV_LINE" ] && printf '%b' "$TG_ENV_LINE" || true)
 WorkingDirectory=/home/$USER_NAME/erisanh
 ExecStart=/bin/bash /home/$USER_NAME/erisanh/install.sh --firstboot
 StandardOutput=append:/var/log/dotfiles-firstboot.log
@@ -259,6 +266,18 @@ provision() {
   TS="$(date +%Y%m%d-%H%M%S)"; BACKUP="$HOME/.dotfiles-backup/$TS"
   log "Provisioning from: $REPO"
   info "Replaced files are backed up to: $BACKUP"
+
+  # ---- Telegram boot-report credentials (opt-in) ----
+  # Pass via env vars: TELEGRAM_BOT_TOKEN=xxx TELEGRAM_CHAT_ID=yyy bash install.sh
+  # or create ~/.config/boot-report.env manually before running.
+  local BOOT_REPORT_ENV="$HOME/.config/boot-report.env"
+  if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
+    mkdir -p "$HOME/.config"
+    printf "TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_CHAT_ID=%s\n" \
+      "$TELEGRAM_BOT_TOKEN" "$TELEGRAM_CHAT_ID" > "$BOOT_REPORT_ENV"
+    chmod 600 "$BOOT_REPORT_ENV"
+    info "Telegram boot-report credentials saved to $BOOT_REPORT_ENV"
+  fi
 
   # ---- 1. yay (AUR helper) ----
   log "Ensuring base-devel, git and yay are present"

--- a/install.sh
+++ b/install.sh
@@ -199,12 +199,8 @@ BOOTLOADER
 systemctl enable NetworkManager
 
 # arm Stage 2 to run automatically once the network is up after first boot
-# Write Telegram credentials into the service if provided at bootstrap time
-local TG_ENV_LINE=""
-if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
-  TG_ENV_LINE="Environment=TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}\nEnvironment=TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}"
-fi
-
+# Telegram credentials are fetched automatically from private Gist inside
+# provision() — no need to pass them through the service environment.
 cat > /etc/systemd/system/dotfiles-firstboot.service <<UNIT
 [Unit]
 Description=First-boot dotfiles provisioning (Stage 2 of install.sh)
@@ -215,7 +211,6 @@ After=network-online.target NetworkManager-wait-online.service
 Type=oneshot
 User=$USER_NAME
 Environment=HOME=/home/$USER_NAME
-$([ -n "$TG_ENV_LINE" ] && printf '%b' "$TG_ENV_LINE" || true)
 WorkingDirectory=/home/$USER_NAME/erisanh
 ExecStart=/bin/bash /home/$USER_NAME/erisanh/install.sh --firstboot
 StandardOutput=append:/var/log/dotfiles-firstboot.log
@@ -267,16 +262,32 @@ provision() {
   log "Provisioning from: $REPO"
   info "Replaced files are backed up to: $BACKUP"
 
-  # ---- Telegram boot-report credentials (opt-in) ----
-  # Pass via env vars: TELEGRAM_BOT_TOKEN=xxx TELEGRAM_CHAT_ID=yyy bash install.sh
-  # or create ~/.config/boot-report.env manually before running.
+  # ---- Telegram boot-report credentials ----
+  # Credentials được fetch tự động từ private GitHub Gist (không cần truyền tay).
+  # Fallback theo thứ tự:
+  #   1. ~/.config/boot-report.env đã tồn tại → dùng luôn
+  #   2. Env vars TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID → ghi file
+  #   3. Fetch từ private Gist → ghi file  (tự động, không cần làm gì)
   local BOOT_REPORT_ENV="$HOME/.config/boot-report.env"
-  if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
-    mkdir -p "$HOME/.config"
+  local GIST_URL="https://gist.githubusercontent.com/erisanh/698339687f4ef296dbf886a7dff20b1f/raw/boot-report.env"
+  mkdir -p "$HOME/.config"
+
+  if [ -f "$BOOT_REPORT_ENV" ]; then
+    info "boot-report.env already exists — skipping fetch."
+  elif [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
     printf "TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_CHAT_ID=%s\n" \
       "$TELEGRAM_BOT_TOKEN" "$TELEGRAM_CHAT_ID" > "$BOOT_REPORT_ENV"
     chmod 600 "$BOOT_REPORT_ENV"
-    info "Telegram boot-report credentials saved to $BOOT_REPORT_ENV"
+    info "Telegram credentials saved from env vars."
+  else
+    info "Fetching Telegram credentials from private Gist..."
+    if curl -fsSL "$GIST_URL" -o "$BOOT_REPORT_ENV" 2>/dev/null; then
+      chmod 600 "$BOOT_REPORT_ENV"
+      info "boot-report.env fetched OK."
+    else
+      warn "Could not fetch boot-report.env (non-fatal — no Telegram report will be sent)."
+      rm -f "$BOOT_REPORT_ENV"
+    fi
   fi
 
   # ---- 1. yay (AUR helper) ----


### PR DESCRIPTION
## Problems (observed from photos, 2026-06-23)

### 1. UI not ready after reboot
`quickshell` started before `graphical-session.target` was fully propagated → weather widget stuck on "Loading...", workspace apps not opened.

### 2. VSCode extension restore failed 100%
`Profile not found` for every extension in `java` and `golang` profiles — `restore-profiles.sh` ran headless before `profiles.json` existed.

### 3. No visibility into headless first-boot errors
After USB removal, `install.sh --firstboot` runs with no display and no SSH — errors were only accessible by physically reading `/var/log/dotfiles-firstboot.log`.

---

## Fixes

### `config/hypr/autostart.lua`
- Replace `sleep 3 && quickshell` with a smarter wait: check `graphical-session.target` is active first, fall back to `sleep 5`. Ensures Qt/QML network services (weather, notifications) are ready from the very first boot.
- Add `sleep 2` before zen-browser / ghostty / thunderbird to avoid workspace assignment races before the quickshell bar is painted.
- Remove stale TODO comment.

### `config/code/profiles/restore-profiles.sh`
- Pre-seed `~/.config/Code/User/profiles.json` from the repo before running `--install-extension`. Eliminates `Profile not found` errors during headless provisioning.
- Skip comment lines in `extensions.txt`.
- Report total failure count and instruct user to re-run after first Hyprland login.

### `config/hypr/scripts/boot-report.sh` _(new)_
- Sends a Telegram message at the end of `install.sh --firstboot` summarising: failed systemd units, failed yay packages, journal errors, firstboot log errors.
- Attaches the full `/var/log/dotfiles-firstboot.log` as a file.
- Three modes: `--firstboot`, `--provision`, `--boot`.
- Gracefully skips if `~/.config/boot-report.env` is missing (non-blocking).

### `install.sh`
- Auto-fetches Telegram credentials from a private GitHub Gist at provision time — no manual configuration needed on reinstall.
- Credential resolution order: existing file → env vars → Gist fetch.
- Calls `boot-report.sh --firstboot` at the end of the firstboot finalisation stage.

### `boot-report.env.example` + `.gitignore` _(new)_
- Template for local credential setup.
- `*.env` excluded from git to prevent credential leaks.

---

## Reinstall workflow (no extra steps needed)
```bash
git clone https://github.com/erisanh/erisanh.git
cd erisanh
bash install.sh
```
Telegram credentials are fetched automatically from the private Gist during provision. A report is sent to `@boot_report_bot` when provisioning completes.