### PR TITLE
fix: i18n + npm audit + VSCode log + boot service + bluetooth + yazi + keyboard audit + activity logger

### DIFF
--- a/boot-report.env.example
+++ b/boot-report.env.example
@@ -1,17 +1,19 @@
-# boot-report.env — Telegram credentials cho boot reporter
+# boot-report.env — Telegram credentials for the boot reporter
 #
-# Sao chép thành ~/.config/boot-report.env rồi điền thông tin:
+# Copy this file to ~/.config/boot-report.env and fill in your values:
 #   cp ~/erisanh/boot-report.env.example ~/.config/boot-report.env
 #   nano ~/.config/boot-report.env
 #   chmod 600 ~/.config/boot-report.env
 #
-# Hoặc truyền qua env var khi chạy install.sh (khuyến nghị cho reinstall):
+# Alternatively, pass credentials via env vars when running install.sh
+# (recommended for reinstalls — no manual step needed):
 #   TELEGRAM_BOT_TOKEN=xxx TELEGRAM_CHAT_ID=yyy bash install.sh
 #
-# Cách lấy thông tin:
-#   Bot:     Telegram → @BotFather → /newbot → lấy token
-#   Chat ID: Gửi /start cho bot → mở https://api.telegram.org/bot<TOKEN>/getUpdates
-#            → tìm result[0].message.chat.id
+# How to get the values:
+#   Bot token: Telegram → @BotFather → /newbot → copy the token
+#   Chat ID:   send /start to your bot, then open
+#              https://api.telegram.org/bot<TOKEN>/getUpdates
+#              and find result[0].message.chat.id
 
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=

--- a/config/code/profiles/restore-profiles.sh
+++ b/config/code/profiles/restore-profiles.sh
@@ -31,6 +31,11 @@ if [ -f "$PROFILES_SRC" ]; then
 fi
 
 # ---- Install extensions per profile ----
+# Failed extensions are written to ~/.dotfiles-failed-vscode-extensions.txt
+# so boot-report.sh can include them in the Telegram notification.
+FAILED_LOG="$HOME/.dotfiles-failed-vscode-extensions.txt"
+rm -f "$FAILED_LOG"   # start fresh each run
+
 FAILED_TOTAL=0
 for d in "$DIR"/*/; do
   name="$(basename "$d")"
@@ -49,6 +54,8 @@ for d in "$DIR"/*/; do
       echo "    ! failed: $ext"
       FAILED_EXTS+=("$ext")
       FAILED_TOTAL=$((FAILED_TOTAL + 1))
+      # Write profile:extension pairs for boot-report.sh to pick up
+      echo "${name}:${ext}" >> "$FAILED_LOG"
     fi
   done < "$list"
 
@@ -61,7 +68,9 @@ done
 echo ""
 if ((FAILED_TOTAL > 0)); then
   echo "Done with $FAILED_TOTAL failure(s). Re-run after first Hyprland login."
+  echo "Failed extensions logged to: $FAILED_LOG"
 else
   echo "Done. All extensions installed successfully."
+  rm -f "$FAILED_LOG"   # no failures — clean up
 fi
 echo "Open VSCode and pick a profile in the bottom-left."

--- a/config/hypr/binds.lua
+++ b/config/hypr/binds.lua
@@ -54,7 +54,9 @@ hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("qs ipc call brightness decreme
 hl.bind("XF86MonBrightnessUp", hl.dsp.exec_cmd("qs ipc call brightness increment || brightnessctl s 5%+"))
 
 -- Power profile
-hl.bind("XF86Launch4", hl.dsp.exec_cmd("qs ipc call powerProfile cycle || asusctl profile --next"))
+-- XF86Launch4 is ASUS-specific and not available on the DAREU 75%.
+-- Power profile cycling is accessible via the quickshell bar instead.
+-- hl.bind("XF86Launch4", hl.dsp.exec_cmd("qs ipc call powerProfile cycle"))
 
 -- -------------------------------------------------------------------------
 -- Media and Volume

--- a/config/hypr/binds.lua
+++ b/config/hypr/binds.lua
@@ -23,8 +23,8 @@ hl.bind(meh .. " + A", hl.dsp.exec_cmd(shared.scripts_path .. "/anim-preset.sh c
 
 -- -------------------------------------------------------------------------
 -- Screenshots (flameshot)
--- NOTE: this DAREU 65% keyboard has NO Print/PrtSc key, so screenshots are on
--- Shift+Alt letter combos instead of the usual Print bindings.
+-- NOTE: this DAREU 75% keyboard has NO dedicated Print/PrtSc key, so screenshots
+-- use Shift+Alt letter combos instead of the usual Print binding.
 -- -------------------------------------------------------------------------
 hl.bind("SHIFT + ALT + S", hl.dsp.exec_cmd("flameshot gui")) -- region: select → annotate → copy/save
 hl.bind("SHIFT + ALT + F", hl.dsp.exec_cmd("flameshot full -c")) -- whole screen → clipboard
@@ -47,7 +47,7 @@ hl.bind("XF86PowerOff", hl.dsp.exec_cmd("qs ipc call session open"))
 hl.bind("SUPER + SHIFT + S", hl.dsp.exec_cmd("qs ipc call session open"))
 -- Super+Space is left free for the fcitx5 Vietnamese toggle (see config/fcitx5)
 hl.bind("SUPER + A", hl.dsp.global("quickshell:launcherToggle")) -- app launcher; was Super+Space
-hl.bind("SUPER + ALT + G", hl.dsp.exec_cmd("qs ipc call gamingMode toggle")) -- no F-row on this 65% board; was Super+F1
+hl.bind("SUPER + ALT + G", hl.dsp.exec_cmd("qs ipc call gamingMode toggle")) -- gaming mode toggle (no F1 shortcut — Fn layer needed on 75%)
 
 -- Brightness with Quickshell fallback
 hl.bind("XF86MonBrightnessDown", hl.dsp.exec_cmd("qs ipc call brightness decrement || brightnessctl s 5%-"))
@@ -77,7 +77,7 @@ hl.bind("SUPER + ALT + P", hl.dsp.exec_cmd("playerctl play-pause"), { locked = t
 hl.bind("SUPER + ALT + bracketright", hl.dsp.exec_cmd("playerctl next"), { locked = true })
 hl.bind("SUPER + ALT + bracketleft", hl.dsp.exec_cmd("playerctl previous"), { locked = true })
 
--- Physical media keys (Fn layer on this 65% board: Fn+7/8/6)
+-- Physical media keys (Fn layer on this 75% board)
 hl.bind("XF86AudioPlay", hl.dsp.exec_cmd("playerctl play-pause"), { locked = true })
 hl.bind("XF86AudioNext", hl.dsp.exec_cmd("playerctl next"), { locked = true })
 hl.bind("XF86AudioPrev", hl.dsp.exec_cmd("playerctl previous"), { locked = true })
@@ -171,7 +171,7 @@ end, { repeating = true })
 -- VM Submap
 -- -------------------------------------------------------------------------
 hl.define_submap("vm", function()
-	-- no F-row on this 65% board; was Super+Alt+F1
+	-- toggle VM submap (Super+Alt+V — avoids Fn layer dependency)
 	hl.bind("SUPER + ALT + V", function()
 		if hl.get_current_submap() == "vm" then
 			hl.dispatch(

--- a/config/hypr/hypridle.conf
+++ b/config/hypr/hypridle.conf
@@ -10,12 +10,15 @@ general {
 #     on-resume = brightnessctl -r                 # monitor backlight restore.
 # }
 
-# turn off keyboard backlight, comment out this section if you dont have a keyboard backlight.
-listener {
-    timeout = 150                                          # 2.5min.
-    on-timeout = brightnessctl -sd asus::kbd_backlight set 0 # turn off keyboard backlight.
-    on-resume = brightnessctl -rd asus::kbd_backlight        # turn on keyboard backlight.
-}
+# Keyboard backlight auto-off.
+# Dareu 75% uses its own USB HID backlight — not the asus::kbd_backlight path.
+# Uncomment and adjust the device name if brightnessctl detects it:
+#   brightnessctl --list   # find the correct device name
+# listener {
+#     timeout = 150
+#     on-timeout = brightnessctl -sd dareu::kbd_backlight set 0
+#     on-resume = brightnessctl -rd dareu::kbd_backlight
+# }
 
 listener {
     timeout = 300                                 # 5min

--- a/config/hypr/scripts/activity-logger.sh
+++ b/config/hypr/scripts/activity-logger.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# activity-logger.sh — stream Hyprland activity events to Telegram
+#
+# Listens on the Hyprland IPC socket2 and batches events into periodic
+# Telegram messages so you can monitor app usage and workspace activity
+# remotely without being spammed per-event.
+#
+# Events tracked:
+#   activewindow  → app focused (class + title, deduped)
+#   openwindow    → new window opened
+#   closewindow   → window closed
+#   workspace     → workspace switched
+#   fullscreen    → fullscreen toggled
+#
+# Config: reads ~/.config/boot-report.env (shared with boot-report.sh)
+#   TELEGRAM_BOT_TOKEN=...
+#   TELEGRAM_CHAT_ID=...
+#
+# Optional overrides in the same file:
+#   ACTIVITY_FLUSH_INTERVAL=300   # seconds between flushes (default: 300)
+#   ACTIVITY_MIN_EVENTS=5         # min events before sending (default: 5)
+#
+# Managed by systemd user service activity-logger.service.
+# ==============================================================================
+set -euo pipefail
+
+CONFIG_FILE="${HOME}/.config/boot-report.env"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "activity-logger: $CONFIG_FILE not found — exiting." >&2
+  exit 0
+fi
+# shellcheck source=/dev/null
+source "$CONFIG_FILE"
+
+if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+  echo "activity-logger: missing credentials in $CONFIG_FILE" >&2
+  exit 0
+fi
+
+FLUSH_INTERVAL="${ACTIVITY_FLUSH_INTERVAL:-300}"
+MIN_EVENTS="${ACTIVITY_MIN_EVENTS:-5}"
+HOSTNAME_STR="$(hostname)"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+tg_send() {
+  curl -s -X POST \
+    "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -d chat_id="${TELEGRAM_CHAT_ID}" \
+    -d parse_mode="HTML" \
+    --data-urlencode "text=$1" \
+    > /dev/null 2>&1 || true
+}
+
+# ── Find Hyprland socket ──────────────────────────────────────────────────────
+find_socket() {
+  local sig="${HYPRLAND_INSTANCE_SIGNATURE:-}"
+  if [ -z "$sig" ]; then
+    sig=$(ls /tmp/hypr/ 2>/dev/null | head -1)
+  fi
+  [ -n "$sig" ] || { echo "activity-logger: no Hyprland instance found" >&2; exit 1; }
+  echo "/tmp/hypr/${sig}/.socket2.sock"
+}
+
+SOCKET="$(find_socket)"
+[ -S "$SOCKET" ] || { echo "activity-logger: socket not found: $SOCKET" >&2; exit 1; }
+
+# ── Batch state (files — avoids subshell scoping issues) ─────────────────────
+BATCH_FILE="$(mktemp /tmp/activity-batch.XXXXXX)"
+BATCH_START_FILE="$(mktemp /tmp/activity-start.XXXXXX)"
+date '+%H:%M:%S' > "$BATCH_START_FILE"
+LAST_FLUSH="$(date +%s)"
+LAST_APP_FILE="$(mktemp /tmp/activity-lastapp.XXXXXX)"
+
+cleanup() { rm -f "$BATCH_FILE" "$BATCH_START_FILE" "$LAST_APP_FILE"; }
+trap cleanup EXIT
+
+append_event() { printf '%s\n' "$1" >> "$BATCH_FILE"; }
+
+flush_batch() {
+  local count
+  count=$(wc -l < "$BATCH_FILE" 2>/dev/null || echo 0)
+
+  if [ "$count" -lt "$MIN_EVENTS" ]; then
+    # Not enough events yet — reset timer but keep batch
+    LAST_FLUSH="$(date +%s)"
+    return
+  fi
+
+  local start end_time
+  start="$(cat "$BATCH_START_FILE")"
+  end_time="$(date '+%H:%M:%S')"
+
+  local header
+  header="$(printf '\xf0\x9f\x93\x8a') <b>Activity — ${HOSTNAME_STR}</b>
+<b>Period:</b> ${start} → ${end_time}  (<b>${count}</b> events)
+"
+  local body
+  body="$(cat "$BATCH_FILE")"
+
+  local msg="${header}${body}"
+  if [ "${#msg}" -gt 4000 ]; then
+    msg="${msg:0:3900}
+<i>... (truncated)</i>"
+  fi
+
+  tg_send "$msg"
+
+  # Reset batch
+  > "$BATCH_FILE"
+  date '+%H:%M:%S' > "$BATCH_START_FILE"
+  LAST_FLUSH="$(date +%s)"
+}
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
+echo "activity-logger: watching $SOCKET (flush every ${FLUSH_INTERVAL}s, min ${MIN_EVENTS} events)"
+
+socat - "UNIX-CONNECT:${SOCKET}" | while IFS= read -r line; do
+  [ -n "$line" ] || continue
+
+  event="${line%%>>*}"
+  data="${line#*>>}"
+  ts="$(date '+%H:%M')"
+
+  case "$event" in
+    activewindow)
+      class="${data%%,*}"
+      title="${data#*,}"
+      last_app="$(cat "$LAST_APP_FILE" 2>/dev/null || true)"
+      if [ -n "$class" ] && [ "$class" != "$last_app" ]; then
+        echo "$class" > "$LAST_APP_FILE"
+        append_event "${ts} $(printf '\xf0\x9f\xaa\x9f') <b>${class}</b> — ${title:0:60}"
+      fi
+      ;;
+    openwindow)
+      class="$(echo "$data" | cut -d',' -f3)"
+      [ -n "$class" ] && append_event "${ts} $(printf '\xe2\x9c\x9a') opened <b>${class}</b>"
+      ;;
+    closewindow)
+      append_event "${ts} $(printf '\xe2\x9c\x96') window closed"
+      ;;
+    workspace)
+      append_event "${ts} $(printf '\xf0\x9f\x93\x8b') workspace $(printf '\xe2\x86\x92') <b>${data}</b>"
+      ;;
+    fullscreen)
+      if [ "$data" = "1" ]; then
+        append_event "${ts} $(printf '\xe2\x9b\xb6') fullscreen on"
+      else
+        append_event "${ts} $(printf '\xe2\x9b\xb6') fullscreen off"
+      fi
+      ;;
+  esac
+
+  # Check if flush interval elapsed
+  now="$(date +%s)"
+  if [ $((now - LAST_FLUSH)) -ge "$FLUSH_INTERVAL" ]; then
+    flush_batch
+  fi
+done
+
+flush_batch

--- a/config/hypr/scripts/boot-report.sh
+++ b/config/hypr/scripts/boot-report.sh
@@ -28,6 +28,7 @@ MODE="${1:---firstboot}"
 CONFIG_FILE="${HOME}/.config/boot-report.env"
 FIRSTBOOT_LOG="/var/log/dotfiles-firstboot.log"
 FAILED_PKG_FILE="${HOME}/.dotfiles-failed-packages.txt"
+FAILED_VSCODE_FILE="${HOME}/.dotfiles-failed-vscode-extensions.txt"
 HOSTNAME_STR="$(hostname)"
 TIMESTAMP="$(date '+%Y-%m-%d %H:%M:%S')"
 
@@ -84,6 +85,21 @@ collect_failed_packages() {
   else
     echo "  (none)"
   fi
+}
+
+collect_vscode_failures() {
+  # Reads ~/.dotfiles-failed-vscode-extensions.txt written by restore-profiles.sh.
+  # Format per line: <profile>:<extension-id>
+  if [ ! -f "$FAILED_VSCODE_FILE" ]; then
+    echo "  (none)"
+    return
+  fi
+  local count
+  count=$(wc -l < "$FAILED_VSCODE_FILE")
+  echo "  ${count} extension(s) failed:"
+  while IFS=: read -r profile ext; do
+    echo "    [${profile}] ${ext}"
+  done < "$FAILED_VSCODE_FILE"
 }
 
 collect_firstboot_errors() {
@@ -190,6 +206,8 @@ build_message() {
     collect_failed_packages
     section "$(printf '\xf0\x9f\x94\xb4') Provision errors (from log)"
     collect_firstboot_errors
+    section "$(printf '\xf0\x9f\x9f\xa5') VSCode extension failures"
+    collect_vscode_failures
   fi
 
   section "$(printf '\xf0\x9f\x94\xb4') Errors (journal)"

--- a/config/hypr/scripts/boot-report.sh
+++ b/config/hypr/scripts/boot-report.sh
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
 # ==============================================================================
-# boot-report.sh — gửi log boot/provision lên Telegram
+# boot-report.sh — send boot/provision log to Telegram
 #
-# Chạy cuối quá trình `install.sh --firstboot` (hoặc --provision) để report
-# kết quả về remote ngay khi máy có mạng, không cần display/Hyprland.
+# Called at the end of `install.sh --firstboot` (or --provision) to report
+# results remotely as soon as the machine has network — no display required.
 #
-# Cách dùng:
+# Usage:
 #   bash boot-report.sh [--firstboot|--provision|--boot]
 #
 # Modes:
-#   --firstboot  : tóm tắt toàn bộ provision + các lỗi (default khi gọi từ install.sh)
-#   --provision  : như firstboot nhưng label "manual provision"
-#   --boot       : report systemd failed units sau mỗi lần reboot bình thường
-#                  (cài vào systemd user service nếu muốn monitor ongoing)
+#   --firstboot  full provision summary + errors (default when called from install.sh)
+#   --provision  same as --firstboot but labelled "manual provision"
+#   --boot       systemd failed units + journal errors/warnings after a normal reboot
+#                (install as a systemd user service for ongoing monitoring)
 #
-# Config: đọc từ ~/.config/boot-report.env (không commit lên git)
+# Config: read from ~/.config/boot-report.env (never committed to git)
 #   TELEGRAM_BOT_TOKEN=123456:ABC...
 #   TELEGRAM_CHAT_ID=9876543
 #
-# Tạo bot: https://t.me/BotFather → /newbot
-# Lấy chat_id: gửi tin nhắn cho bot rồi truy cập
+# Create a bot: https://t.me/BotFather → /newbot
+# Get chat_id:  send any message to the bot, then open
 #   https://api.telegram.org/bot<TOKEN>/getUpdates
 # ==============================================================================
 set -euo pipefail
@@ -34,10 +34,6 @@ TIMESTAMP="$(date '+%Y-%m-%d %H:%M:%S')"
 # ── Load credentials ──────────────────────────────────────────────────────────
 if [ ! -f "$CONFIG_FILE" ]; then
   echo "boot-report: $CONFIG_FILE not found — skipping remote report." >&2
-  echo "Create it with:" >&2
-  echo "  echo 'TELEGRAM_BOT_TOKEN=xxx' >> $CONFIG_FILE" >&2
-  echo "  echo 'TELEGRAM_CHAT_ID=yyy'   >> $CONFIG_FILE" >&2
-  echo "  chmod 600 $CONFIG_FILE" >&2
   exit 0
 fi
 # shellcheck source=/dev/null
@@ -51,7 +47,6 @@ fi
 # ── Helpers ───────────────────────────────────────────────────────────────────
 tg_send() {
   local text="$1"
-  # Telegram MarkdownV2 — escape special chars
   curl -s -X POST \
     "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
     -d chat_id="${TELEGRAM_CHAT_ID}" \
@@ -72,45 +67,87 @@ tg_file() {
 }
 
 section() { printf '\n<b>%s</b>\n' "$1"; }
+uptime_str() { uptime -p 2>/dev/null || uptime; }
+kernel_str()  { uname -r; }
+disk_usage()  { df -h / 2>/dev/null | awk 'NR==2{print $3 " used / " $2 " total (" $5 ")"}'; }
 
-# ── Collect info ──────────────────────────────────────────────────────────────
+# ── Collectors ────────────────────────────────────────────────────────────────
 collect_failed_units() {
   systemctl --failed --no-legend --no-pager 2>/dev/null \
-    | awk '{print "  ● " $1}' | head -20 || echo "  (none)"
+    | awk '{print "  \xe2\x97\x8f " $1}' | head -20 \
+    || echo "  (none)"
 }
 
 collect_failed_packages() {
   if [ -f "$FAILED_PKG_FILE" ]; then
-    awk '{print "  ✗ " $0}' "$FAILED_PKG_FILE" | head -30
+    awk '{print "  \xe2\x9c\x97 " $0}' "$FAILED_PKG_FILE" | head -30
   else
     echo "  (none)"
   fi
 }
 
-collect_journal_errors() {
-  # Last boot errors from journald (priority err and above), skip noisy lines
-  journalctl -b -p err --no-pager --no-hostname -q 2>/dev/null \
-    | grep -v -E "Failed to load.*theme|use-gl.*Electron|Bluetooth|hci|rfkill" \
-    | tail -30 \
-    | sed 's/^/  /' \
-    || echo "  (none or journald unavailable)"
-}
-
 collect_firstboot_errors() {
   if [ -f "$FIRSTBOOT_LOG" ]; then
-    grep -i -E "error|fail|warn|✗|!" "$FIRSTBOOT_LOG" \
+    grep -i -E "error|fail|warn|!|✗" "$FIRSTBOOT_LOG" \
       | grep -v "^$\|install.sh\|backup" \
       | tail -40 \
       | sed 's/^/  /' \
-      || echo "  (no errors found in log)"
+      || echo "  (none)"
   else
     echo "  (firstboot log not found)"
   fi
 }
 
-uptime_str() { uptime -p 2>/dev/null || uptime; }
-kernel_str()  { uname -r; }
-disk_usage()  { df -h / 2>/dev/null | awk 'NR==2{print $3 " used / " $2 " total (" $5 ")"}'; }
+collect_journal_errors() {
+  # priority 0-3: emerg, alert, crit, err
+  journalctl -b -p err --no-pager --no-hostname -q 2>/dev/null \
+    | grep -v -E "Failed to load.*theme|use-gl.*Electron|Bluetooth|hci|rfkill" \
+    | tail -20 \
+    | sed 's/^/  /' \
+    || echo "  (none)"
+}
+
+collect_journal_warnings() {
+  # priority 4: warning only (excludes err+ already shown above)
+  journalctl -b -p warning..warning --no-pager --no-hostname -q 2>/dev/null \
+    | grep -v -E "use-gl.*Electron|deprecated|Bluetooth|hci|rfkill|Failed to load.*theme|NetworkManager.*device" \
+    | tail -15 \
+    | sed 's/^/  /' \
+    || echo "  (none)"
+}
+
+collect_npm_audit() {
+  # Scan npm projects under common dirs for high/critical vulnerabilities.
+  # Silently skips if npm is not installed or no package.json found.
+  command -v npm >/dev/null 2>&1 || { echo "  (npm not installed)"; return; }
+
+  local results="" dir high critical out
+  local search_dirs=("$HOME/src" "$HOME/projects" "$HOME/work" "$HOME/erisanh")
+
+  for base in "${search_dirs[@]}"; do
+    [ -d "$base" ] || continue
+    while IFS= read -r dir; do
+      out=$(cd "$dir" && npm audit --json 2>/dev/null || true)
+      high=$(echo "$out" \
+        | python3 -c "import sys,json; d=json.load(sys.stdin); \
+          print(d.get('metadata',{}).get('vulnerabilities',{}).get('high',0))" 2>/dev/null || echo 0)
+      critical=$(echo "$out" \
+        | python3 -c "import sys,json; d=json.load(sys.stdin); \
+          print(d.get('metadata',{}).get('vulnerabilities',{}).get('critical',0))" 2>/dev/null || echo 0)
+      if [ "${high:-0}" -gt 0 ] || [ "${critical:-0}" -gt 0 ]; then
+        local label="${dir/#$HOME/\~}"
+        results="${results}  $(printf '\xf0\x9f\x93\x81') ${label} — high: ${high}, critical: ${critical}\n"
+      fi
+    done < <(find "$base" -maxdepth 3 -name "package.json" \
+               ! -path "*/node_modules/*" -printf '%h\n' 2>/dev/null | sort -u)
+  done
+
+  if [ -z "$results" ]; then
+    echo "  (no vulnerabilities found)"
+  else
+    printf '%b' "$results"
+  fi
+}
 
 # ── Build message ─────────────────────────────────────────────────────────────
 build_message() {
@@ -118,44 +155,51 @@ build_message() {
   local icon title
 
   case "$mode" in
-    --firstboot) icon="🚀"; title="First-boot provision complete" ;;
-    --provision) icon="🔧"; title="Manual provision complete" ;;
-    --boot)      icon="⚡"; title="System boot report" ;;
-    *)           icon="📋"; title="Boot report" ;;
+    --firstboot) icon="$(printf '\xf0\x9f\x9a\x80')"; title="First-boot provision complete" ;;
+    --provision) icon="$(printf '\xf0\x9f\x94\xa7')"; title="Manual provision complete" ;;
+    --boot)      icon="$(printf '\xe2\x9a\xa1')";      title="System boot report" ;;
+    *)           icon="$(printf '\xf0\x9f\x93\x8b')"; title="Boot report" ;;
   esac
 
-  local failed_units
+  # Collect once, reuse in message and for status icon
+  local failed_units errors warnings
   failed_units="$(collect_failed_units)"
+  errors="$(collect_journal_errors)"
+  warnings="$(collect_journal_warnings)"
 
-  local status_icon="✅"
-  if echo "$failed_units" | grep -q "●"; then
-    status_icon="⚠️"
+  # Status icon: red = failed units, yellow = errors only, green = clean
+  local status_icon="$(printf '\xe2\x9c\x85')"
+  if echo "$failed_units" | grep -q "$(printf '\xe2\x97\x8f')"; then
+    status_icon="$(printf '\xf0\x9f\x94\xb4')"
+  elif ! echo "$errors" | grep -q "(none)"; then
+    status_icon="$(printf '\xe2\x9a\xa0\xef\xb8\x8f')"
   fi
 
-  cat <<MSG
-${status_icon} <b>${icon} ${title}</b>
-<b>Host:</b> ${HOSTNAME_STR}
-<b>Time:</b> ${TIMESTAMP}
-<b>Uptime:</b> $(uptime_str)
-<b>Kernel:</b> $(kernel_str)
-<b>Disk /:</b> $(disk_usage)
-$(section "❌ Failed systemd units")
-${failed_units}
-MSG
+  printf '%s <b>%s %s</b>\n' "$status_icon" "$icon" "$title"
+  printf '<b>Host:</b> %s\n' "$HOSTNAME_STR"
+  printf '<b>Time:</b> %s\n' "$TIMESTAMP"
+  printf '<b>Uptime:</b> %s\n' "$(uptime_str)"
+  printf '<b>Kernel:</b> %s\n' "$(kernel_str)"
+  printf '<b>Disk /:</b> %s\n' "$(disk_usage)"
+
+  section "$(printf '\xe2\x9d\x8c') Failed systemd units"
+  printf '%s\n' "$failed_units"
 
   if [ "$mode" != "--boot" ]; then
-    cat <<MSG
-$(section "📦 Failed packages (yay)")
-$(collect_failed_packages)
-$(section "🔴 Provision errors (from log)")
-$(collect_firstboot_errors)
-MSG
+    section "$(printf '\xf0\x9f\x93\xa6') Failed packages (yay)"
+    collect_failed_packages
+    section "$(printf '\xf0\x9f\x94\xb4') Provision errors (from log)"
+    collect_firstboot_errors
   fi
 
-  cat <<MSG
-$(section "🔴 Journal errors (this boot)")
-$(collect_journal_errors)
-MSG
+  section "$(printf '\xf0\x9f\x94\xb4') Errors (journal)"
+  printf '%s\n' "$errors"
+
+  section "$(printf '\xe2\x9a\xa0\xef\xb8\x8f') Warnings (journal)"
+  printf '%s\n' "$warnings"
+
+  section "$(printf '\xf0\x9f\x94\x92') npm audit (high/critical only)"
+  collect_npm_audit
 }
 
 # ── Send ──────────────────────────────────────────────────────────────────────
@@ -164,14 +208,14 @@ MSG="$(build_message "$MODE")"
 # Telegram message limit is 4096 chars — truncate if needed
 if [ "${#MSG}" -gt 4000 ]; then
   MSG="${MSG:0:3900}
-<i>... (truncated, see attached log)</i>"
+<i>... (truncated — see attached log for full output)</i>"
 fi
 
 tg_send "$MSG"
 
-# Also attach full firstboot log if it exists and we're in provision mode
+# Attach full firstboot log in provision modes
 if [ "$MODE" != "--boot" ] && [ -f "$FIRSTBOOT_LOG" ]; then
-  tg_file "📄 Full firstboot log — ${HOSTNAME_STR} ${TIMESTAMP}" "$FIRSTBOOT_LOG"
+  tg_file "Full firstboot log — ${HOSTNAME_STR} ${TIMESTAMP}" "$FIRSTBOOT_LOG"
 fi
 
 echo "boot-report: sent to Telegram."

--- a/config/systemd/user/activity-logger.service
+++ b/config/systemd/user/activity-logger.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Hyprland activity logger — stream events to Telegram
+# Must run inside an active Hyprland session (socket lives there)
+After=graphical-session.target
+Requires=graphical-session.target
+
+[Service]
+Type=simple
+# Give Hyprland 3s to write its socket before we try to connect
+ExecStartPre=/usr/bin/sleep 3
+ExecStart=/bin/bash %h/.config/hypr/scripts/activity-logger.sh
+Restart=on-failure
+RestartSec=10s
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=graphical-session.target

--- a/config/systemd/user/boot-report.service
+++ b/config/systemd/user/boot-report.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Send boot error/warning report to Telegram
+# Run after network is up so curl can reach api.telegram.org
+Wants=network-online.target
+After=network-online.target
+# Also wait for graphical session so journald has collected startup logs
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+# Wait 30s for systemd to finish starting all units before sampling failed ones
+ExecStartPre=/usr/bin/sleep 30
+ExecStart=/bin/bash %h/.config/hypr/scripts/boot-report.sh --boot
+StandardOutput=journal
+StandardError=journal
+# Non-fatal — never block login
+RemainAfterExit=no
+
+[Install]
+WantedBy=graphical-session.target

--- a/config/yazi/yazi.toml
+++ b/config/yazi/yazi.toml
@@ -30,7 +30,7 @@ open = [
 
 [open]
 rules = [
-	{ name = "*/", use = [ "edit", "open", "reveal" ] },
+	{ mime = "inode/directory", use = [ "edit", "open", "reveal" ] },
 	{ mime = "text/*", use = [ "edit", "reveal" ] },
 	{ mime = "image/*", use = [ "open", "reveal" ] },
 	{ mime = "video/*", use = [ "open", "reveal" ] },

--- a/install.sh
+++ b/install.sh
@@ -263,11 +263,11 @@ provision() {
   info "Replaced files are backed up to: $BACKUP"
 
   # ---- Telegram boot-report credentials ----
-  # Credentials được fetch tự động từ private GitHub Gist (không cần truyền tay).
-  # Fallback theo thứ tự:
-  #   1. ~/.config/boot-report.env đã tồn tại → dùng luôn
-  #   2. Env vars TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID → ghi file
-  #   3. Fetch từ private Gist → ghi file  (tự động, không cần làm gì)
+  # Credentials are fetched automatically from a private GitHub Gist.
+  # Resolution order (first match wins):
+  #   1. ~/.config/boot-report.env already exists → use as-is (idempotent)
+  #   2. Env vars TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_ID are set → write file
+  #   3. Auto-fetch from private Gist → write boot-report.env + chmod 600
   local BOOT_REPORT_ENV="$HOME/.config/boot-report.env"
   local GIST_URL="https://gist.githubusercontent.com/erisanh/698339687f4ef296dbf886a7dff20b1f/raw/boot-report.env"
   mkdir -p "$HOME/.config"
@@ -466,9 +466,9 @@ Next steps (one-time):
   • GPU: desktop runs on the Intel iGPU (no NVIDIA driver installed by default).
   • [Optional] Enable Telegram boot reports — run once after first login:
       cp ~/erisanh/boot-report.env.example ~/.config/boot-report.env
-      nano ~/.config/boot-report.env   # điền BOT_TOKEN + CHAT_ID
+      nano ~/.config/boot-report.env   # fill in BOT_TOKEN + CHAT_ID
       chmod 600 ~/.config/boot-report.env
-    Hướng dẫn lấy token/chat_id: xem boot-report.env.example
+    Setup guide: see boot-report.env.example
 
 Replaced files (if any) were backed up to: $BACKUP
 EOF

--- a/install.sh
+++ b/install.sh
@@ -428,12 +428,18 @@ provision() {
   # a summary of failed units, journal errors and warnings on each boot.
   # Symlinked via the dotfiles link step; just needs to be enabled here.
   local BOOT_REPORT_SVC="$HOME/.config/systemd/user/boot-report.service"
-  if [ -f "$BOOT_REPORT_SVC" ]; then
-    systemctl --user daemon-reload 2>/dev/null || true
-    systemctl --user enable boot-report.service 2>/dev/null       && info "enabled boot-report.service (user)"       || warn "could not enable boot-report.service (non-fatal)"
-  else
-    warn "boot-report.service not found at $BOOT_REPORT_SVC — skipping."
-  fi
+  local ACTIVITY_SVC="$HOME/.config/systemd/user/activity-logger.service"
+  systemctl --user daemon-reload 2>/dev/null || true
+  for _svc in boot-report.service activity-logger.service; do
+    _svc_path="$HOME/.config/systemd/user/${_svc}"
+    if [ -f "$_svc_path" ]; then
+      systemctl --user enable "$_svc" 2>/dev/null \
+        && info "enabled ${_svc} (user)" \
+        || warn "could not enable ${_svc} (non-fatal)"
+    else
+      warn "${_svc} not found — skipping."
+    fi
+  done
 
   # ---- 6. zram (plan section 8) ----
   log "Configuring zram"

--- a/install.sh
+++ b/install.sh
@@ -364,8 +364,14 @@ provision() {
       *)          link "$path" "$HOME/.config/$name" ;;
     esac
   done
-  link "$REPO/nvim"       "$HOME/.config/nvim"
-  link "$REPO/quickshell" "$HOME/.config/quickshell"
+  link "$REPO/nvim"                "$HOME/.config/nvim"
+  link "$REPO/quickshell"          "$HOME/.config/quickshell"
+  # systemd user units (boot-report.service, etc.)
+  mkdir -p "$HOME/.config/systemd/user"
+  for svc in "$REPO"/config/systemd/user/*.service "$REPO"/config/systemd/user/*.timer; do
+    [ -e "$svc" ] || continue
+    link "$svc" "$HOME/.config/systemd/user/$(basename "$svc")"
+  done
 
   # ---- 4. VSCode: shared settings/keybindings + restore profiles ----
   log "Setting up VSCode (stable)"
@@ -415,6 +421,18 @@ provision() {
   enable_unit power-profiles-daemon.service power-profiles-daemon
   if pacman -Qq docker >/dev/null 2>&1; then
     sudo usermod -aG docker "$ME" && info "added $ME to the docker group (re-login to apply)"
+  fi
+
+  # ---- boot-report systemd user service ----
+  # Runs boot-report.sh --boot after every login so Telegram receives
+  # a summary of failed units, journal errors and warnings on each boot.
+  # Symlinked via the dotfiles link step; just needs to be enabled here.
+  local BOOT_REPORT_SVC="$HOME/.config/systemd/user/boot-report.service"
+  if [ -f "$BOOT_REPORT_SVC" ]; then
+    systemctl --user daemon-reload 2>/dev/null || true
+    systemctl --user enable boot-report.service 2>/dev/null       && info "enabled boot-report.service (user)"       || warn "could not enable boot-report.service (non-fatal)"
+  else
+    warn "boot-report.service not found at $BOOT_REPORT_SVC — skipping."
   fi
 
   # ---- 6. zram (plan section 8) ----

--- a/keys.en.md
+++ b/keys.en.md
@@ -90,7 +90,7 @@
 | `SUPER + Alt + P` | Play / pause |
 | `SUPER + Alt + [ / ]` | Previous / next track |
 | `XF86AudioPlay / Next / Prev` | Play-pause / next / prev (media Fn keys) |
-| `XF86Launch4` | Cycle power profile |
+| Power profile | Accessible via quickshell bar (no dedicated key on DAREU 75%) |
 
 ### Misc
 | Key | Action |

--- a/keys.en.md
+++ b/keys.en.md
@@ -1,6 +1,7 @@
 # Keybindings & Common Commands
 
 > Cheat sheet for this dotfiles workspace (Arch + Hyprland + ghostty + fish).
+> Keyboard: **DAREU 75%** (has F1–F12 row; no dedicated PrtSc key).
 > Notation: **SUPER** = Super/Windows key · **MEH** = `Ctrl+Shift+Alt`.
 > Source of truth: `config/hypr/binds.lua`, `config/ghostty/config`, `config/tmux/tmux.conf`, `config/fish/`.
 
@@ -30,7 +31,7 @@
 | `SUPER + Alt + G` | Toggle gaming mode |
 
 ### Screenshots & OCR (flameshot)
-> This keyboard has no Print/PrtSc key, so screenshots use Shift+Alt combos.
+> This keyboard (DAREU 75%) has no dedicated Print/PrtSc key, so screenshots use Shift+Alt combos.
 
 | Key | Action |
 | --- | --- |
@@ -88,7 +89,7 @@
 | `XF86MonBrightnessUp / Down` | Brightness |
 | `SUPER + Alt + P` | Play / pause |
 | `SUPER + Alt + [ / ]` | Previous / next track |
-| `XF86AudioPlay / Next / Prev` | Play-pause / next / prev (Fn+7 / Fn+8 / Fn+6) |
+| `XF86AudioPlay / Next / Prev` | Play-pause / next / prev (media Fn keys) |
 | `XF86Launch4` | Cycle power profile |
 
 ### Misc

--- a/quickshell/modules/controlCenter/bluetoothDevice/BluetoothPanel.qml
+++ b/quickshell/modules/controlCenter/bluetoothDevice/BluetoothPanel.qml
@@ -13,6 +13,20 @@ Rectangle {
 
     signal closePanel
 
+    // Auto-discover when panel is shown so BlueZ can resolve device names.
+    // Names are fetched lazily by BlueZ only during an active scan — without
+    // this, nearby devices appear as raw MAC addresses.
+    Component.onCompleted: {
+        const adapter = Bluetooth.defaultAdapter;
+        if (adapter && adapter.enabled && !adapter.discovering)
+            adapter.discovering = true;
+    }
+    Component.onDestruction: {
+        const adapter = Bluetooth.defaultAdapter;
+        if (adapter && adapter.discovering)
+            adapter.discovering = false;
+    }
+
     color: Appearance.m3colors.m3background
     radius: 20
     border.width: 1
@@ -67,22 +81,28 @@ Rectangle {
             spacing: 0
 
             model: ScriptModel {
-                values: [...Bluetooth.devices.values].sort((a, b) => {
-                    // Connected -> paired -> others
-                    let conn = (b.connected - a.connected) || (b.paired - a.paired);
-                    if (conn !== 0)
-                        return conn;
+                id: deviceModel
 
-                    // Ones with meaningful names before MAC addresses
-                    const macRegex = /^([0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}$/;
-                    const aIsMac = macRegex.test(a.name);
-                    const bIsMac = macRegex.test(b.name);
-                    if (aIsMac !== bIsMac)
-                        return aIsMac ? 1 : -1;
+                readonly property var macRegex: /^([0-9A-Fa-f]{2}[:\-]){5}[0-9A-Fa-f]{2}$/
 
-                    // Alphabetical by name
-                    return a.name.localeCompare(b.name);
-                })
+                values: [...Bluetooth.devices.values]
+                    .filter(d => {
+                        // Always show paired/connected devices regardless of name
+                        if (d.paired || d.connected) return true;
+                        // Hide devices whose "name" is just a raw MAC address —
+                        // BlueZ uses the MAC as a placeholder until it resolves
+                        // the real name via a device info request. These unnamed
+                        // entries clutter the list without being actionable.
+                        return !deviceModel.macRegex.test(d.name);
+                    })
+                    .sort((a, b) => {
+                        // Connected first, then paired, then others
+                        const conn = (b.connected - a.connected) || (b.paired - a.paired);
+                        if (conn !== 0)
+                            return conn;
+                        // Alphabetical by name
+                        return a.name.localeCompare(b.name);
+                    })
             }
             delegate: BluetoothDeviceItem {
                 required property BluetoothDevice modelData
@@ -107,7 +127,7 @@ Rectangle {
             spacing: 4
 
             RippleButton {
-                id: detailButton
+                id: scanButton
                 implicitHeight: 36
                 implicitWidth: 80
                 padding: 14
@@ -116,14 +136,20 @@ Rectangle {
 
                 contentItem: Text {
                     anchors.fill: parent
-                    anchors.leftMargin: detailButton.padding
-                    anchors.rightMargin: detailButton.padding
-                    text: "Details"
+                    anchors.leftMargin: scanButton.padding
+                    anchors.rightMargin: scanButton.padding
+                    text: (Bluetooth.defaultAdapter?.discovering ?? false) ? "Scanning…" : "Scan"
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     font.pixelSize: 12
                     font.bold: true
-                    color: detailButton.enabled ? Appearance.colors.colOnLayer0 : Appearance.m3colors.m3background
+                    color: scanButton.enabled ? Appearance.colors.colOnLayer0 : Appearance.m3colors.m3background
+                }
+
+                onClicked: {
+                    const adapter = Bluetooth.defaultAdapter;
+                    if (!adapter || !adapter.enabled) return;
+                    adapter.discovering = !adapter.discovering;
                 }
             }
 


### PR DESCRIPTION
## Changes in this PR

### fix: translate Vietnamese comments to English
- `boot-report.sh`, `install.sh`, `boot-report.env.example`

### feat: npm audit reporting in Telegram
- `collect_npm_audit()`: scans npm projects, reports high/critical only

### feat: log VSCode profile extension failures to Telegram
- `restore-profiles.sh`: writes `~/.dotfiles-failed-vscode-extensions.txt`
- `boot-report.sh`: new `collect_vscode_failures()` section

### feat: run boot-report on every boot via systemd user service
- New `config/systemd/user/boot-report.service`
- Runs `boot-report.sh --boot` after every graphical session login

### feat: Telegram activity logger
- New `config/hypr/scripts/activity-logger.sh`
  - Tails Hyprland IPC socket2 events in real-time
  - Tracks: app focus, window open/close, workspace switch, fullscreen
  - Batches events, flushes every 5 min (configurable)
- New `config/systemd/user/activity-logger.service`
- `install.sh`: enable both services during provision

### fix: bluetooth shows real device names
- `BluetoothPanel.qml`: auto-start discovery when panel opens
- Filter out MAC-address-only unnamed unpaired devices
- Replace non-functional Details button with Scan toggle

### fix: yazi TOML parse error
- `yazi.toml` line 33: `name="*/"` → `mime="inode/directory"`

### fix: keyboard audit — remove ASUS-specific bindings
- `binds.lua`: comment out `XF86Launch4` (ASUS-only, not on DAREU 75%)
- `hypridle.conf`: replace `asus::kbd_backlight` with commented template
- `keys.en.md`: update power profile row
- Fix all 65% references → 75% (DAREU 75% has F1–F12 row)