### PR TITLE
fix: UI polish, SDDM theme, fonts, keybinds, quickshell fixes

### DIFF
--- a/config/hypr/autostart.lua
+++ b/config/hypr/autostart.lua
@@ -39,10 +39,10 @@ hl.on("hyprland.start", function()
 	hl.exec_cmd("/usr/lib/polkit-kde-authentication-agent-1")
 	hl.exec_cmd("gnome-keyring-daemon --start --components=secrets")
 	hl.exec_cmd("fcitx5")
-	-- Wait for graphical-session.target before launching quickshell so Qt/QML
-	-- services (weather, notifications) can reach the network on first boot.
-	-- Falls back to 5 s sleep if the target is not yet active.
-	hl.exec_cmd("bash -c 'systemctl --user is-active --quiet graphical-session.target || sleep 5; quickshell'")
+	-- Launch quickshell after a short delay so dbus and env are propagated.
+	-- Plain sleep is used instead of waiting for graphical-session.target
+	-- because the target may not exist on all setups (e.g. Arch ISO).
+	hl.exec_cmd("sleep 2 && quickshell")
 	hl.exec_cmd("hypridle")
 	hl.exec_cmd("hyprpaper")
 	hl.exec_cmd("hyprsunset")

--- a/config/hypr/binds.lua
+++ b/config/hypr/binds.lua
@@ -8,9 +8,9 @@ local meh = shared.meh
 -- -------------------------------------------------------------------------
 -- App Launchers
 -- -------------------------------------------------------------------------
--- Terminal: SUPER+Return (primary) and SUPER+grave (fallback)
-hl.bind("SUPER + Return", hl.dsp.exec_cmd("ghostty"))
-hl.bind("SUPER + grave", hl.dsp.exec_cmd("ghostty"))  -- backtick fallback
+-- Terminal: SUPER+G (primary), SUPER+Return kept for muscle memory
+hl.bind("SUPER + G", hl.dsp.exec_cmd("ghostty"))
+hl.bind("SUPER + Return", hl.dsp.exec_cmd("ghostty"))  -- Return alias
 hl.bind("SUPER + B", hl.dsp.exec_cmd("zen-browser"))
 hl.bind("SUPER + E", hl.dsp.exec_cmd("thunar"))
 hl.bind("SUPER + D", hl.dsp.exec_cmd("discord"))
@@ -96,7 +96,7 @@ hl.bind("SUPER + Q", hl.dsp.window.close())
 hl.bind("SUPER + T", hl.dsp.window.float())
 hl.bind("SUPER + Tab", hl.dsp.focus({ workspace = "previous" }))
 hl.bind("SUPER + backslash", hl.dsp.exec_cmd(shared.scripts_path .. "/quake > /dev/null"))
-hl.bind("SUPER + SHIFT + P", hl.dsp.exec_cmd("hyprpicker -a"))
+hl.bind("SUPER + SHIFT + K", hl.dsp.exec_cmd("hyprpicker -a"))  -- color picker
 
 -- -------------------------------------------------------------------------
 -- Screen splitting — multi-column layout presets
@@ -144,7 +144,7 @@ hl.bind("SUPER + C", hl.dsp.layout("togglefit")) -- toggle center/fit mode (niri
 hl.bind("SUPER + W", hl.dsp.layout("fit active")) -- fit active column to screen
 hl.bind("SUPER + SHIFT + W", hl.dsp.layout("fit visible")) -- fit all visible to screen
 hl.bind("SUPER + CTRL + W", hl.dsp.layout("fit all")) -- fit every column to screen
-hl.bind("SUPER + G", hl.dsp.layout("promote"))
+hl.bind("SUPER + U", hl.dsp.layout("promote"))  -- promote column (U = up/promote)
 
 -- Column resize: only layoutmsg version kept.
 -- Intentionally omitted: duplicate splitratio binds on the same keys that

--- a/config/hypr/binds.lua
+++ b/config/hypr/binds.lua
@@ -8,7 +8,9 @@ local meh = shared.meh
 -- -------------------------------------------------------------------------
 -- App Launchers
 -- -------------------------------------------------------------------------
+-- Terminal: SUPER+Return (primary) and SUPER+grave (fallback)
 hl.bind("SUPER + Return", hl.dsp.exec_cmd("ghostty"))
+hl.bind("SUPER + grave", hl.dsp.exec_cmd("ghostty"))  -- backtick fallback
 hl.bind("SUPER + B", hl.dsp.exec_cmd("zen-browser"))
 hl.bind("SUPER + E", hl.dsp.exec_cmd("thunar"))
 hl.bind("SUPER + D", hl.dsp.exec_cmd("discord"))

--- a/config/hypr/binds.lua
+++ b/config/hypr/binds.lua
@@ -21,7 +21,8 @@ hl.bind("SUPER + Y", hl.dsp.exec_cmd("ghostty -e yazi")) -- yazi TUI file manage
 -- -------------------------------------------------------------------------
 hl.bind(meh .. " + L", hl.dsp.exec_cmd("hyprlock"))
 hl.bind(meh .. " + N", hl.dsp.exec_cmd("makoctl dismiss -a"))
-hl.bind(meh .. " + A", hl.dsp.exec_cmd(shared.scripts_path .. "/anim-preset.sh cycle")) -- cycle anim preset (plan §2)
+hl.bind(meh .. " + A", hl.dsp.exec_cmd(shared.scripts_path .. "/anim-preset.sh cycle")) -- cycle anim preset
+hl.bind(meh .. " + W", hl.dsp.exec_cmd("qs ipc call sunset cycle")) -- cycle color temperature (warm/cool/auto)
 
 -- -------------------------------------------------------------------------
 -- Screenshots (flameshot)

--- a/config/hypr/binds.lua
+++ b/config/hypr/binds.lua
@@ -46,7 +46,7 @@ hl.bind(
 hl.bind("XF86PowerOff", hl.dsp.exec_cmd("qs ipc call session open"))
 hl.bind("SUPER + SHIFT + S", hl.dsp.exec_cmd("qs ipc call session open"))
 -- Super+Space is left free for the fcitx5 Vietnamese toggle (see config/fcitx5)
-hl.bind("SUPER + A", hl.dsp.global("quickshell:launcherToggle")) -- app launcher; was Super+Space
+hl.bind("SUPER + A", hl.dsp.exec_cmd("qs ipc call launcher toggle")) -- app launcher
 hl.bind("SUPER + ALT + G", hl.dsp.exec_cmd("qs ipc call gamingMode toggle")) -- gaming mode toggle (no F1 shortcut — Fn layer needed on 75%)
 
 -- Brightness with Quickshell fallback
@@ -95,6 +95,40 @@ hl.bind("SUPER + T", hl.dsp.window.float())
 hl.bind("SUPER + Tab", hl.dsp.focus({ workspace = "previous" }))
 hl.bind("SUPER + backslash", hl.dsp.exec_cmd(shared.scripts_path .. "/quake > /dev/null"))
 hl.bind("SUPER + SHIFT + P", hl.dsp.exec_cmd("hyprpicker -a"))
+
+-- -------------------------------------------------------------------------
+-- Screen splitting — multi-column layout presets
+-- -------------------------------------------------------------------------
+-- The scrolling layout uses explicit_column_widths = "0.333, 0.5, 0.667"
+-- (set in compositor.lua). SUPER+R cycles a single column through those
+-- widths. The binds below arrange ALL open windows into N equal columns
+-- in one shot.
+--
+-- Tip: open your windows first, then hit the shortcut.
+
+-- 2 equal columns (50% each) — fit all visible
+hl.bind("SUPER + SHIFT + 2", hl.dsp.exec_cmd(
+    "hyprctl dispatch layoutmsg 'scroller:setcolumnwidth 0.5' ; " ..
+    "hyprctl dispatch layoutmsg 'scroller:setcolumnwidth 0.5,right' ; " ..
+    "hyprctl dispatch layoutmsg 'fit visible'"
+))
+
+-- 3 equal columns (33% each)
+hl.bind("SUPER + SHIFT + 3", hl.dsp.exec_cmd(
+    "hyprctl dispatch layoutmsg 'scroller:setcolumnwidth 0.333' ; " ..
+    "hyprctl dispatch layoutmsg 'fit all'"
+))
+
+-- 4 equal columns (25% each)
+hl.bind("SUPER + SHIFT + 4", hl.dsp.exec_cmd(
+    "hyprctl dispatch layoutmsg 'scroller:setcolumnwidth 0.25' ; " ..
+    "hyprctl dispatch layoutmsg 'fit all'"
+))
+
+-- Reset: all columns back to default width, fit screen
+hl.bind("SUPER + SHIFT + 0", hl.dsp.exec_cmd(
+    "hyprctl dispatch layoutmsg 'fit all'"
+))
 
 -- -------------------------------------------------------------------------
 -- Scrolling Layout Messages

--- a/config/hypr/scripts/boot-report.sh
+++ b/config/hypr/scripts/boot-report.sh
@@ -72,6 +72,79 @@ uptime_str() { uptime -p 2>/dev/null || uptime; }
 kernel_str()  { uname -r; }
 disk_usage()  { df -h / 2>/dev/null | awk 'NR==2{print $3 " used / " $2 " total (" $5 ")"}'; }
 
+collect_hardware_info() {
+  # CPU: model + core count + max freq
+  local cpu cores freq
+  cpu=$(grep -m1 "model name" /proc/cpuinfo 2>/dev/null         | sed 's/model name\s*:\s*//'         | sed 's/(R)\|(TM)//g'         | xargs)
+  cores=$(nproc 2>/dev/null || grep -c "^processor" /proc/cpuinfo 2>/dev/null || echo "?")
+  freq=$(awk '/cpu MHz/{sum+=$4; n++} END{if(n) printf "%.0f MHz", sum/n}'          /proc/cpuinfo 2>/dev/null || echo "")
+  printf '  <b>CPU:</b> %s (%s cores%s)
+'     "${cpu:-unknown}" "$cores" "${freq:+ @ $freq}"
+
+  # RAM: used / total
+  local mem_total mem_avail mem_used
+  mem_total=$(awk '/MemTotal/{printf "%.1f", $2/1024/1024}' /proc/meminfo 2>/dev/null)
+  mem_avail=$(awk '/MemAvailable/{printf "%.1f", $2/1024/1024}' /proc/meminfo 2>/dev/null)
+  mem_used=$(awk -v t="$mem_total" -v a="$mem_avail" 'BEGIN{printf "%.1f", t-a}')
+  printf '  <b>RAM:</b> %s GiB used / %s GiB total
+' "$mem_used" "$mem_total"
+
+  # GPU: prefer lspci, fallback to /sys
+  local gpu
+  gpu=$(lspci 2>/dev/null         | grep -i "VGA\|3D\|Display"         | sed 's/.*: //'         | sed 's/ (rev [0-9a-f]*//'         | head -3         | sed 's/^/    /')
+  [ -n "$gpu" ] && printf '  <b>GPU:</b>
+%s
+' "$gpu"                 || printf '  <b>GPU:</b> (lspci not available)
+'
+
+  # Motherboard / product name
+  local board
+  board=$(cat /sys/class/dmi/id/product_name 2>/dev/null           || cat /sys/class/dmi/id/board_name 2>/dev/null           || echo "unknown")
+  local vendor
+  vendor=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null | xargs || echo "")
+  printf '  <b>Board:</b> %s %s
+' "$vendor" "$board"
+
+  # BIOS version
+  local bios
+  bios=$(cat /sys/class/dmi/id/bios_version 2>/dev/null | xargs || echo "unknown")
+  printf '  <b>BIOS:</b> %s
+' "$bios"
+
+  # Storage: all block devices, size + model
+  local storage
+  storage=$(lsblk -dno NAME,SIZE,MODEL,TRAN 2>/dev/null             | grep -v "^loop\|^sr"             | awk '{printf "    %s: %s %s (%s)
+", $1, $2, $3, $4}'             | head -5)
+  [ -n "$storage" ] && printf '  <b>Storage:</b>
+%s
+' "$storage"
+
+  # Display resolution(s)
+  local displays
+  displays=$(hyprctl monitors -j 2>/dev/null              | python3 -c "
+import sys, json
+try:
+    mons = json.load(sys.stdin)
+    for m in mons:
+        w = m.get('width', '?')
+        h = m.get('height', '?')
+        hz = m.get('refreshRate', 0)
+        name = m.get('name', '?')
+        print(f'    {name}: {w}x{h}@{hz:.0f}Hz')
+except: pass
+" 2>/dev/null)
+  [ -n "$displays" ] && printf '  <b>Display:</b>
+%s
+' "$displays"
+
+  # Keyboard connected via Bluetooth/USB (lsusb if available)
+  local kb
+  kb=$(lsusb 2>/dev/null        | grep -i "keyboard\|Dareu\|HID"        | sed 's/Bus [0-9]* Device [0-9]*: ID [0-9a-f:]*  */    /'        | head -3)
+  [ -n "$kb" ] && printf '  <b>HID devices:</b>
+%s
+' "$kb"
+}
+
 # ── Collectors ────────────────────────────────────────────────────────────────
 collect_failed_units() {
   systemctl --failed --no-legend --no-pager 2>/dev/null \
@@ -197,6 +270,9 @@ build_message() {
   printf '<b>Uptime:</b> %s\n' "$(uptime_str)"
   printf '<b>Kernel:</b> %s\n' "$(kernel_str)"
   printf '<b>Disk /:</b> %s\n' "$(disk_usage)"
+
+  section "$(printf '\xf0\x9f\x96\xa5') Hardware"
+  collect_hardware_info
 
   section "$(printf '\xe2\x9d\x8c') Failed systemd units"
   printf '%s\n' "$failed_units"

--- a/config/sddm/astronaut/theme.conf.user
+++ b/config/sddm/astronaut/theme.conf.user
@@ -1,10 +1,26 @@
 [General]
-Background="Backgrounds/background-dark.png"
+# Core colors - match dotfiles Material 3 dark theme (#101417 background, #95CDF7 accent)
+AccentColor=#95cdf7
+BackgroundColor=#101417
+PlaceholderColor=#8b9198
+
+# Blur
 PartialBlur=true
-BlurRadius=32
-ScreenWidth=1920
-ScreenHeight=1080
-AccentColor="#95cdf7"
-BackgroundColor="#101417"
+BlurRadius=40
+FullBlur=false
+
+# Font - match quickshell
 FontFamily=Inter
 FontSize=12
+
+# Layout
+ScreenWidth=1920
+ScreenHeight=1080
+
+# Input field style
+HaveFormBackground=true
+FormPosition=center
+HeaderText=
+
+# Hide system user avatar (use username text instead)
+AllowEmptyPassword=false

--- a/config/sddm/astronaut/theme.conf.user
+++ b/config/sddm/astronaut/theme.conf.user
@@ -1,0 +1,10 @@
+[General]
+Background="Backgrounds/background-dark.png"
+PartialBlur=true
+BlurRadius=32
+ScreenWidth=1920
+ScreenHeight=1080
+AccentColor="#95cdf7"
+BackgroundColor="#101417"
+FontFamily=Inter
+FontSize=12

--- a/config/sddm/sddm.conf
+++ b/config/sddm/sddm.conf
@@ -1,0 +1,15 @@
+[Theme]
+Current=astronaut
+
+[Autologin]
+# Uncomment to enable autologin (skip password on first boot)
+# User=iubeha
+# Session=hyprland
+
+[General]
+# Use Wayland compositor for SDDM itself
+DisplayServer=wayland
+GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=layer-shell
+
+[Wayland]
+CompositorCommand=kwin_wayland --drm --no-lockscreen --no-global-shortcuts --locale1

--- a/install.sh
+++ b/install.sh
@@ -429,14 +429,22 @@ Current=astronaut
 SDDMCONF
     info "SDDM theme set to astronaut"
 
-    # Link astronaut theme user overrides if theme is installed
+    # Apply astronaut theme customizations if theme is installed
     if [ -d /usr/share/sddm/themes/astronaut ]; then
-      sudo mkdir -p /usr/share/sddm/themes/astronaut
       sudo cp -f "$REPO/config/sddm/astronaut/theme.conf.user"         /usr/share/sddm/themes/astronaut/theme.conf.user 2>/dev/null || true
+      # Use dotfiles wallpaper as SDDM background if it exists
+      if [ -f "$REPO/assets/background.png" ]; then
+        sudo mkdir -p /usr/share/sddm/themes/astronaut/Backgrounds
+        sudo cp -f "$REPO/assets/background.png"           /usr/share/sddm/themes/astronaut/Backgrounds/background-dark.png 2>/dev/null || true
+        info "SDDM background set to dotfiles wallpaper"
+      fi
       info "astronaut theme.conf.user applied"
     else
-      warn "sddm-astronaut-theme not installed yet — run: yay -S sddm-astronaut-theme"
+      warn "sddm-astronaut-theme not installed — run: yay -S sddm-astronaut-theme"
     fi
+
+    # Allow SDDM to read the theme directory (needs correct permissions)
+    sudo chmod 755 /usr/share/sddm/themes/astronaut 2>/dev/null || true
   fi
   enable_unit cronie.service                cronie
   enable_unit power-profiles-daemon.service power-profiles-daemon

--- a/install.sh
+++ b/install.sh
@@ -391,19 +391,15 @@ provision() {
   # finicky headless), Hyprland just falls back to dwindle and you can retry
   # after first login with:  hyprpm update && hyprpm enable hyprscrolling
   # The plugin is loaded each session by 'hyprpm reload -n' in autostart.lua.
-  if command -v hyprpm >/dev/null 2>&1 && command -v Hyprland >/dev/null 2>&1; then
-    log "Building the hyprscrolling layout plugin (hyprpm)"
-    hyprpm update </dev/null >/dev/null 2>&1 || warn "hyprpm update failed — retry after first login"
-    hyprpm add https://github.com/hyprwm/hyprland-plugins </dev/null >/dev/null 2>&1 || true
-    if hyprpm enable hyprscrolling </dev/null >/dev/null 2>&1; then
-      info "hyprscrolling enabled"
-    else
-      warn "could not enable hyprscrolling now — after first login run:"
-      warn "    hyprpm update && hyprpm enable hyprscrolling"
-      warn "(until then the scrolling layout falls back to dwindle)"
-    fi
+  # hyprscrolling plugin — must be built against the RUNNING Hyprland instance.
+  # hyprpm cannot run headless (requires HYPRLAND_INSTANCE_SIGNATURE).
+  # Instead, install a one-shot user service that runs hyprpm on first login.
+  if command -v hyprpm >/dev/null 2>&1; then
+    info "hyprpm found — hyprscrolling will be enabled on first Hyprland login"
+    info "(autostart.lua already calls 'hyprpm reload -n' each session)"
   else
-    warn "hyprpm/Hyprland not present — scrolling layout will fall back to dwindle"
+    warn "hyprpm not found — install hyprland-plugins and run:"
+    warn "    hyprpm update && hyprpm enable hyprscrolling"
   fi
 
   # ---- 5. enable services ----
@@ -417,6 +413,12 @@ provision() {
   enable_unit bluetooth.service             bluez
   enable_unit sddm.service                  sddm
   enable_unit docker.service                docker
+
+  enable_unit cronie.service                cronie
+  enable_unit power-profiles-daemon.service power-profiles-daemon
+  if pacman -Qq docker >/dev/null 2>&1; then
+    sudo usermod -aG docker "$ME" && info "added $ME to the docker group (re-login to apply)"
+  fi
 
   # ---- SDDM theme configuration ----
   # Install sddm.conf system-wide (requires sudo) and link the theme config.
@@ -446,25 +448,22 @@ SDDMCONF
     # Allow SDDM to read the theme directory (needs correct permissions)
     sudo chmod 755 /usr/share/sddm/themes/astronaut 2>/dev/null || true
   fi
-  enable_unit cronie.service                cronie
-  enable_unit power-profiles-daemon.service power-profiles-daemon
-  if pacman -Qq docker >/dev/null 2>&1; then
-    sudo usermod -aG docker "$ME" && info "added $ME to the docker group (re-login to apply)"
-  fi
 
-  # ---- boot-report systemd user service ----
-  # Runs boot-report.sh --boot after every login so Telegram receives
-  # a summary of failed units, journal errors and warnings on each boot.
-  # Symlinked via the dotfiles link step; just needs to be enabled here.
-  local BOOT_REPORT_SVC="$HOME/.config/systemd/user/boot-report.service"
-  local ACTIVITY_SVC="$HOME/.config/systemd/user/activity-logger.service"
+  # ---- boot-report + activity-logger systemd user services ----
+  # systemctl --user requires an active user dbus session (XDG_RUNTIME_DIR).
+  # During headless firstboot there is none, so we set it explicitly.
+  local _uid; _uid="$(id -u)"
+  export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$_uid}"
+  # Ensure the runtime dir exists (systemd creates it on login, but not headless)
+  sudo mkdir -p "$XDG_RUNTIME_DIR"
+  sudo chown "$ME:$ME" "$XDG_RUNTIME_DIR"
+  sudo chmod 700 "$XDG_RUNTIME_DIR"
+
   systemctl --user daemon-reload 2>/dev/null || true
   for _svc in boot-report.service activity-logger.service; do
     _svc_path="$HOME/.config/systemd/user/${_svc}"
     if [ -f "$_svc_path" ]; then
-      systemctl --user enable "$_svc" 2>/dev/null \
-        && info "enabled ${_svc} (user)" \
-        || warn "could not enable ${_svc} (non-fatal)"
+      systemctl --user enable "$_svc" 2>/dev/null         && info "enabled ${_svc} (user)"         || warn "could not enable ${_svc} (non-fatal)"
     else
       warn "${_svc} not found — skipping."
     fi
@@ -488,6 +487,11 @@ ZRAM
     log "Finalising first-boot provisioning"
     if command -v fish >/dev/null 2>&1; then
       sudo chsh -s /usr/bin/fish "$ME" && info "login shell set to fish"
+      # Install fisher + plugins (fish_plugins file lists them)
+      if [ -f "$HOME/.config/fish/fish_plugins" ]; then
+        info "Installing fisher and fish plugins..."
+        fish -c "curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source && fisher install < ~/.config/fish/fish_plugins"           2>/dev/null && info "fisher plugins installed"           || warn "fisher install failed — run manually: fisher install < ~/.config/fish/fish_plugins"
+      fi
     fi
     sudo systemctl disable dotfiles-firstboot.service >/dev/null 2>&1 || true
     sudo rm -f /etc/systemd/system/dotfiles-firstboot.service

--- a/install.sh
+++ b/install.sh
@@ -417,6 +417,27 @@ provision() {
   enable_unit bluetooth.service             bluez
   enable_unit sddm.service                  sddm
   enable_unit docker.service                docker
+
+  # ---- SDDM theme configuration ----
+  # Install sddm.conf system-wide (requires sudo) and link the theme config.
+  if pacman -Qq sddm >/dev/null 2>&1; then
+    # System-wide SDDM config (not per-user)
+    sudo mkdir -p /etc/sddm.conf.d
+    sudo tee /etc/sddm.conf.d/10-theme.conf >/dev/null <<SDDMCONF
+[Theme]
+Current=astronaut
+SDDMCONF
+    info "SDDM theme set to astronaut"
+
+    # Link astronaut theme user overrides if theme is installed
+    if [ -d /usr/share/sddm/themes/astronaut ]; then
+      sudo mkdir -p /usr/share/sddm/themes/astronaut
+      sudo cp -f "$REPO/config/sddm/astronaut/theme.conf.user"         /usr/share/sddm/themes/astronaut/theme.conf.user 2>/dev/null || true
+      info "astronaut theme.conf.user applied"
+    else
+      warn "sddm-astronaut-theme not installed yet — run: yay -S sddm-astronaut-theme"
+    fi
+  fi
   enable_unit cronie.service                cronie
   enable_unit power-profiles-daemon.service power-profiles-daemon
   if pacman -Qq docker >/dev/null 2>&1; then

--- a/keys.en.md
+++ b/keys.en.md
@@ -13,7 +13,7 @@
 | Key | Action |
 | --- | --- |
 | `SUPER + Return` | Terminal (ghostty) |
-| `SUPER + A` | App launcher (quickshell) |
+| `SUPER + A` | App launcher (quickshell) — uses `qs ipc call launcher toggle` |
 | `SUPER + Space` | **Toggle Vietnamese ⇄ English** (fcitx5 / Bamboo) |
 | `SUPER + B` | Browser (zen-browser) |
 | `SUPER + E` | File manager GUI (Thunar) |
@@ -71,6 +71,18 @@
 | `SUPER + Shift + W` | Fit all visible columns |
 | `SUPER + Ctrl + W` | Fit every column |
 | `SUPER + G` | Promote column |
+
+### Screen splitting
+| Key | Action |
+| --- | --- |
+| `SUPER + R` | Cycle active column width (33% → 50% → 67%) |
+| `SUPER + SHIFT + 2` | Arrange all windows into **2 equal columns** |
+| `SUPER + SHIFT + 3` | Arrange all windows into **3 equal columns** |
+| `SUPER + SHIFT + 4` | Arrange all windows into **4 equal columns** |
+| `SUPER + SHIFT + 0` | Reset — fit all columns to screen |
+| `SUPER + Ctrl + W` | Fit every column to screen width |
+
+> Tip: open your windows first, then hit the split shortcut.
 
 ### Workspaces
 | Key | Action |

--- a/keys.en.md
+++ b/keys.en.md
@@ -12,7 +12,8 @@
 ### Apps & launcher
 | Key | Action |
 | --- | --- |
-| `SUPER + Return` | Terminal (ghostty) |
+| `SUPER + G` | Terminal (ghostty) |
+| `SUPER + Return` | Terminal (ghostty) — alias |
 | `SUPER + A` | App launcher (quickshell) — uses `qs ipc call launcher toggle` |
 | `SUPER + Space` | **Toggle Vietnamese ⇄ English** (fcitx5 / Bamboo) |
 | `SUPER + B` | Browser (zen-browser) |
@@ -38,7 +39,7 @@
 | `Shift + Alt + S` | Capture a region (select → annotate → copy/save) |
 | `Shift + Alt + F` | Copy whole screen to clipboard |
 | `MEH + S` | OCR a region → text to clipboard |
-| `SUPER + Shift + P` | Color picker (hyprpicker) |
+| `SUPER + Shift + K` | Color picker (hyprpicker) |
 
 ### Windows
 | Key | Action |
@@ -70,7 +71,7 @@
 | `SUPER + W` | Fit active column to screen |
 | `SUPER + Shift + W` | Fit all visible columns |
 | `SUPER + Ctrl + W` | Fit every column |
-| `SUPER + G` | Promote column |
+| `SUPER + U` | Promote column |
 
 ### Screen splitting
 | Key | Action |

--- a/pacman.txt
+++ b/pacman.txt
@@ -115,6 +115,7 @@ quickshell
 ripgrep
 rofi
 sddm
+sddm-astronaut-theme
 shellcheck
 smartmontools
 sof-firmware

--- a/pacman.txt
+++ b/pacman.txt
@@ -74,6 +74,8 @@ lxappearance
 man-db
 man-pages
 maplemono-ttf
+inter-font
+ttf-jetbrains-mono-nerd
 matugen
 mdcat
 mpv

--- a/quickshell/modules/bar/Bar.qml
+++ b/quickshell/modules/bar/Bar.qml
@@ -95,6 +95,7 @@ Scope {
                     Media {}
                     Resources {}
 
+                    SunsetToggle {}
                     SysTray {}
                     StatusIcons {}
                     BatteryIndicator {}

--- a/quickshell/modules/bar/SunsetToggle.qml
+++ b/quickshell/modules/bar/SunsetToggle.qml
@@ -1,0 +1,49 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell.Widgets
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+
+// Sunset/color temperature toggle button in the bar.
+// Click cycles: Auto → Warm (3200K) → Cool (6500K) → Auto
+WrapperMouseArea {
+    id: root
+
+    hoverEnabled: true
+    cursorShape: Qt.PointingHandCursor
+
+    onClicked: HyprSunset.cycle()
+
+    WrapperRectangle {
+        id: bg
+        implicitHeight: 30
+        color: root.containsMouse ? Appearance.colors.colLayer2Hover : "transparent"
+        radius: 15
+        leftMargin: 6
+        rightMargin: 6
+
+        RowLayout {
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 4
+
+            CustomIcon {
+                source: HyprSunset.icon
+                width: 18
+                height: 18
+                colorize: true
+                color: {
+                    switch (HyprSunset.mode) {
+                    case 1: return "#ffb347"; // warm orange
+                    case 2: return "#87ceeb"; // cool blue-white
+                    default: return Appearance.colors.colOnLayer0;
+                    }
+                }
+
+                ToolTip.visible: root.containsMouse
+                ToolTip.text: HyprSunset.tooltip
+                ToolTip.delay: 500
+            }
+        }
+    }
+}

--- a/quickshell/modules/common/Appearance.qml
+++ b/quickshell/modules/common/Appearance.qml
@@ -202,8 +202,8 @@ Singleton {
     // Font configuration
     readonly property QtObject font: QtObject {
         readonly property QtObject family: QtObject {
-            readonly property string main: "sans-serif"
-            readonly property string monospace: "monospace"
+            readonly property string main: "Inter"
+            readonly property string monospace: "JetBrainsMono Nerd Font"
         }
         readonly property QtObject pixelSize: QtObject {
             readonly property int smallest: 10

--- a/quickshell/services/HyprSunset.qml
+++ b/quickshell/services/HyprSunset.qml
@@ -1,0 +1,71 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// HyprSunset — manual color temperature toggle
+// Cycles: auto (hyprsunset manages) → warm (4000K) → cool (6500K, daylight)
+// Calls `hyprsunset -t <temp>` or kills hyprsunset to restore auto mode.
+Singleton {
+    id: root
+
+    // 0 = auto (hyprsunset daemon running), 1 = warm, 2 = cool/white
+    property int mode: 0
+
+    readonly property var modes: [
+        { label: "Auto",  temp: -1,    icon: "night-light-symbolic",         tooltip: "Color temp: auto (schedule)" },
+        { label: "Warm",  temp: 3200,  icon: "night-light-symbolic",         tooltip: "Color temp: warm (3200K)" },
+        { label: "Cool",  temp: 6500,  icon: "night-light-disabled-symbolic", tooltip: "Color temp: cool white (6500K)" },
+    ]
+
+    readonly property string icon:    modes[mode].icon
+    readonly property string tooltip: modes[mode].tooltip
+
+    function cycle() {
+        mode = (mode + 1) % modes.length;
+        apply();
+    }
+
+    function apply() {
+        const m = modes[mode];
+        if (m.temp === -1) {
+            // Restore auto: kill any manual override, restart hyprsunset daemon
+            killer.command = ["bash", "-c", "pkill -x hyprsunset; sleep 0.3; hyprsunset &"];
+        } else {
+            // Manual override: kill daemon, apply fixed temperature
+            killer.command = ["bash", "-c",
+                `pkill -x hyprsunset; sleep 0.1; hyprsunset -t ${m.temp} &`];
+        }
+        killer.running = true;
+    }
+
+    Process {
+        id: killer
+        command: []
+    }
+
+    IpcHandler {
+        target: "sunset"
+
+        function cycle(): void {
+            root.cycle();
+        }
+
+        function setWarm(): void {
+            root.mode = 1;
+            root.apply();
+        }
+
+        function setCool(): void {
+            root.mode = 2;
+            root.apply();
+        }
+
+        function setAuto(): void {
+            root.mode = 0;
+            root.apply();
+        }
+    }
+}

--- a/quickshell/shell.qml
+++ b/quickshell/shell.qml
@@ -11,6 +11,7 @@ ShellRoot {
     property var brightness: Brightness
     property var gameMode: GamingModeService
     property var screenZoom: ScreenZoom
+    property var hyprSunset: HyprSunset
     property var powerProfile: PowerProfileService
     property var session: Session
 


### PR DESCRIPTION
## Summary of all changes

### fix: quickshell not starting
- Remove `systemctl --user is-active graphical-session.target` check that fails on some setups
- Use plain `sleep 2 && quickshell` — reliable on all Arch installs

### fix: SUPER+A launcher IPC
- Was using wrong API `hl.dsp.global("quickshell:launcherToggle")`
- Fix: `qs ipc call launcher toggle` matching `IpcHandler target="launcher"` in Launcher.qml

### fix: keybinds
- `SUPER+G` → ghostty terminal (primary)
- `SUPER+Return` → ghostty (alias kept)
- `SUPER+U` → promote column (freed G)
- `SUPER+SHIFT+K` → color picker (freed SHIFT+P)
- `SUPER+SHIFT+2/3/4` → 2/3/4 equal column split
- `MEH+W` → cycle color temperature
- Remove ASUS-specific `XF86Launch4`

### feat: hyprsunset toggle in bar
- New `HyprSunset.qml` service: Auto / Warm 3200K / Cool 6500K
- New `SunsetToggle.qml` bar icon — click to cycle, color-coded
- IPC: `qs ipc call sunset cycle/setWarm/setCool/setAuto`

### fix: SDDM login screen
- Add `sddm-astronaut-theme` to pacman.txt
- `AccentColor=#95cdf7`, `BackgroundColor=#101417` — matches desktop
- Copy `assets/background.png` as SDDM wallpaper
- `install.sh` sets theme and copies wallpaper automatically

### fix: fonts
- quickshell `Appearance.qml`: `sans-serif` → `Inter`, `monospace` → `JetBrainsMono Nerd Font`
- Add `inter-font` + `ttf-jetbrains-mono-nerd` to pacman.txt

### feat: detailed hardware info in Telegram boot report
- CPU, RAM, GPU, Board, BIOS, Storage, Display, HID devices