### PR TITLE
fix: reinstall reliability — SDDM, session, deps, broken symlinks

### DIFF
--- a/config/bat/themes/tokyonight
+++ b/config/bat/themes/tokyonight
@@ -1,1 +1,0 @@
-/home/monarch/ghq/github.com/folke/tokyonight.nvim/extras/sublime/

--- a/config/bat/themes/tokyonight/tokyonight_day.tmTheme
+++ b/config/bat/themes/tokyonight/tokyonight_day.tmTheme
@@ -1,0 +1,1377 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Folke Lemaitre (http://github.com/folke)</string>
+	<key>colorSpaceName</key>
+	<string>sRGB</string>
+	<key>name</key>
+	<string>TokyoNight</string>
+	<key>semanticClass</key>
+	<string>enki.theme.tokyo</string>
+	<key>settings</key>
+	<array>
+		<dict>
+			<key>settings</key>
+			<dict>
+				<key>activeGuide</key>
+				<string>#363b54</string>
+				<key>background</key>
+				<string>#e1e2e7</string>
+				<key>caret</key>
+				<string>#DBC08A</string>
+				<key>findHighlight</key>
+				<string>#ffa300</string>
+				<key>findHighlightForeground</key>
+				<string>#000000</string>
+				<key>foreground</key>
+				<string>#3760bf</string>
+				<key>guide</key>
+				<string>#4f4f5e40</string>
+				<key>gutterForeground</key>
+				<string>#3b415caa</string>
+				<key>inactiveSelection</key>
+				<string>#282833</string>
+				<key>invisibles</key>
+				<string>#4f4f5e</string>
+				<key>lineHighlight</key>
+				<string>#00000030</string>
+				<key>selection</key>
+				<string>#9D599D40</string>
+				<key>selectionBorder</key>
+				<string>#9D599D</string>
+				<key>shadow</key>
+				<string>#00000010</string>
+				<key>stackGuide</key>
+				<string>#4f4f5e60</string>
+				<key>tagsOptions</key>
+				<string>underline</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Italics - Comments, Storage, Keyword Flow, Vue attributes, Decorators</string>
+			<key>scope</key>
+			<string>comment, meta.var.expr storage.type, keyword.control.flow, meta.directive.vue punctuation.separator.key-value.html, meta.directive.vue entity.other.attribute-name.html, tag.decorator.js entity.name.tag.js, tag.decorator.js punctuation.definition.tag.js, storage.modifier</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment</string>
+			<key>scope</key>
+			<string>comment, comment.block.documentation, punctuation.definition.comment</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#848cb5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment Doc</string>
+			<key>scope</key>
+			<string>comment.block.documentation variable, comment.block.documentation storage, comment.block.documentation punctuation, comment.block.documentation keyword, comment.block.documentation support, comment.block.documentation markup, comment.block.documentation markup.inline.raw.string.markdown, keyword.other.phpdoc.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#848cb5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Number, Boolean, Undefined, Null</string>
+			<key>scope</key>
+			<string>variable.other.constant, punctuation.definition.constant, constant.language, constant.numeric, support.constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b15c00</string>
+			</dict>
+		</dict>
+    <dict>
+      <key>name</key>
+      <string>String, Symbols, Markup Heading</string>
+      <key>scope</key>
+      <string>meta.property.lua,string.unquoted.key.lua,support.other.metaproperty.lua,support.other.metaproperty.lua,constant.other.symbol, constant.other.key, markup.heading, meta.attribute-selector</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string></string>
+        <key>foreground</key>
+        <string>#387068</string>
+      </dict>
+    </dict>
+		<dict>
+			<key>name</key>
+			<string>String</string>
+			<key>scope</key>
+			<string>string</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#587539</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Colors</string>
+			<key>scope</key>
+			<string>constant.other.color, constant.other.color.rgb-value.hex punctuation.definition.constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Info</string>
+			<key>scope</key>
+			<string>markup.info</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#07879d</string>
+				<key>background</key>
+				<string>#cbd9e0</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Warning</string>
+			<key>scope</key>
+			<string>markup.warning</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#8c6c3e</string>
+				<key>background</key>
+				<string>#d9d6d6</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Error</string>
+			<key>scope</key>
+			<string>markup.error</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c64343</string>
+				<key>background</key>
+				<string>#ded2d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Invalid</string>
+			<key>scope</key>
+			<string>invalid, invalid.illegal</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Invalid deprecated</string>
+			<key>scope</key>
+			<string>invalid.deprecated</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Storage Type</string>
+			<key>scope</key>
+			<string>storage.type</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Storage - modifier, var, const, let</string>
+			<key>scope</key>
+			<string>meta.var.expr storage.type, storage.modifier</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7847bd</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Interpolation</string>
+			<key>scope</key>
+			<string>punctuation.definition.template-expression, punctuation.section.embedded</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#007197</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Spread</string>
+			<key>scope</key>
+			<string>keyword.operator.spread, keyword.operator.rest</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Operator, Misc</string>
+			<key>scope</key>
+			<string>keyword.operator, keyword.control.as, keyword.other, keyword.operator.bitwise.shift, punctuation, punctuation.definition.constant.markdown, punctuation.definition.string, punctuation.support.type.property-name, text.html.vue-html meta.tag, punctuation.definition.keyword, punctuation.terminator.rule, punctuation.definition.entity, punctuation.definition.tag, punctuation.separator.inheritance.php, punctuation.definition.tag.html, keyword.other.template, keyword.other.substitution, entity.name.operator, text.html.vue meta.tag.block.any.html, text.html.vue meta.tag.inline.any.html, text.html.vue meta.tag.other.html, text.html.twig meta.tag.inline.any.html, text.html.twig meta.tag.block.any.html, text.html.twig meta.tag.structure.any.html, text.html.twig meta.tag.any.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#006a83</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Import, Export, From, Default</string>
+			<key>scope</key>
+			<string>keyword.control.import, keyword.control.export, keyword.control.from, keyword.control.default, meta.import keyword.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#007197</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword</string>
+			<key>scope</key>
+			<string>keyword, keyword.control, keyword.other.important</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword SQL</string>
+			<key>scope</key>
+			<string>keyword.other.DML</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#007197</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword Operator Logical, Arrow, Ternary, Comparison</string>
+			<key>scope</key>
+			<string>keyword.operator.logical, storage.type.function, keyword.operator.bitwise, keyword.operator.ternary, keyword.operator.comparison, keyword.operator.relational, keyword.operator.or.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Tag</string>
+			<key>scope</key>
+			<string>entity.name.tag, entity.name.tag support.class.component, meta.tag</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Tag Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.tag, punctuation.definition.tag.html, punctuation.definition.tag.begin.html, punctuation.definition.tag.end.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ba3c97</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Blade</string>
+			<key>scope</key>
+			<string>keyword.blade, entity.name.function.blade</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2e7de9</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>PHP - Embedded Tag</string>
+			<key>scope</key>
+			<string>punctuation.section.embedded.begin.php, punctuation.section.embedded.end.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#07879d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Smarty - Twig tag - Blade</string>
+			<key>scope</key>
+			<string>punctuation.definition.variable.smarty, punctuation.section.embedded.begin.smarty, punctuation.section.embedded.end.smarty, meta.tag.template.value.twig, punctuation.section.tag.twig, meta.tag.expression.twig, punctuation.definition.tag.expression.twig, punctuation.definition.tag.output.twig, variable.parameter.smarty</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7DCFFF</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Smarty - Twig variable - function</string>
+			<key>scope</key>
+			<string>variable.other.property.twig, support.function.twig, meta.function-call.twig, keyword.control.twig, keyword.control.smarty, keyword.operator.other.twig, keyword.operator.comparison.twig, support.function.functions.twig, support.function.functions.twig, keyword.operator.assignment.twig, support.function.filters.twig, support.function.built-in.smarty, keyword.operator.smarty, text.blade text.html.blade custom.compiler.blade.php punctuation.section.embedded.php entity.name.tag.block.any.html, text.blade text.html.blade custom.compiler.blade.php punctuation.section.embedded.php constant.other.inline-data.html, text.blade text.html.blade custom.compiler.blade.php support.function constant.other.inline-data.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#188092</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Globals - PHP Constants  etc</string>
+			<key>scope</key>
+			<string>constant.other.php, variable.other.global.safer, variable.other.global.safer punctuation.definition.variable, variable.other.global, variable.other.global punctuation.definition.variable, constant.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#8c6c3e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variables</string>
+			<key>scope</key>
+			<string>variable, support.variable, string constant.other.placeholder</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Variable</string>
+			<key>scope</key>
+			<string>variable.other.object, support.module.node</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Key</string>
+			<key>scope</key>
+			<string>meta.object-literal.key, meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js, string.alias.graphql, string.unquoted.graphql, string.unquoted.alias.graphql, meta.field.declaration.ts variable.object.property</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#387068</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Property</string>
+			<key>scope</key>
+			<string>variable.other.property, support.variable.property, support.variable.property.dom, meta.function-call variable.other.object.property, variable.language.prototype, meta.property.object, variable.other.member</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#007197</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Property</string>
+			<key>scope</key>
+			<string>variable.other.object.property</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Literal Member lvl 3 (Vue Prop Validation)</string>
+			<key>scope</key>
+			<string>meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#38919f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>C-related Block Level Variables</string>
+			<key>scope</key>
+			<string>source.cpp meta.block variable.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Other Variable</string>
+			<key>scope</key>
+			<string>support.other.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Methods</string>
+			<key>scope</key>
+			<string>meta.class-method.js entity.name.function.js, entity.name.method.js, variable.function.constructor, keyword.other.special-method, storage.type.cs</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2e7de9</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function Definition</string>
+			<key>scope</key>
+			<string>entity.name.function, meta.function-call, meta.function-call entity.name.function, variable.function, meta.definition.method entity.name.function, meta.object-literal entity.name.function</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2e7de9</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function Argument</string>
+			<key>scope</key>
+			<string>variable.parameter.function.language.special, variable.parameter, meta.function.parameters punctuation.definition.variable, meta.function.parameter variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#8c6c3e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Constant, Tag Attribute</string>
+			<key>scope</key>
+			<string>keyword.other.type.php, storage.type.php, constant.character, constant.escape, keyword.other.unit</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable Definition</string>
+			<key>scope</key>
+			<string>meta.definition.variable variable.other.constant, meta.definition.variable variable.other.readwrite, variable.other.declaration</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Inherited Class</string>
+			<key>scope</key>
+			<string>entity.other.inherited-class</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Class, Support, DOM, etc</string>
+			<key>scope</key>
+			<string>support.class, support.type, variable.other.readwrite.alias, support.orther.namespace.use.php, meta.use.php, support.other.namespace.php, support.type.sys-types, support.variable.dom, support.constant.math, support.type.object.module, support.constant.json, entity.name.namespace, meta.import.qualifier, entity.name.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#07879d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Class Name</string>
+			<key>scope</key>
+			<string>entity.name</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Support Function</string>
+			<key>scope</key>
+			<string>support.function</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#188092</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Class and Support</string>
+			<key>scope</key>
+			<string>source.css support.type.property-name, source.sass support.type.property-name, source.scss support.type.property-name, source.less support.type.property-name, source.stylus support.type.property-name, source.postcss support.type.property-name, support.type.property-name.css, support.type.vendored.property-name, support.type.map.key</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2e7de9</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Font</string>
+			<key>scope</key>
+			<string>support.constant.font-name, meta.definition.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#587539</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Class</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.class, meta.at-rule.mixin.scss entity.name.function.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#587539</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS ID</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.id</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#fc7b7b</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Tag</string>
+			<key>scope</key>
+			<string>entity.name.tag.css, entity.name.tag.reference, entity.name.tag.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#07879d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Tag Reference</string>
+			<key>scope</key>
+			<string>entity.name.tag.reference</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#8c6c3e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Property Separator</string>
+			<key>scope</key>
+			<string>meta.property-list punctuation.separator.key-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Punctuation</string>
+			<key>scope</key>
+			<string>meta.property-list, punctuation.definition.entity.css</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#8c6c3e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS @</string>
+			<key>scope</key>
+			<string>meta.at-rule.mixin keyword.control.at-rule.mixin, meta.at-rule.include entity.name.function.scss, meta.at-rule.include keyword.control.at-rule.include</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS Mixins, Extends, Include Keyword</string>
+			<key>scope</key>
+			<string>keyword.control.at-rule.include punctuation.definition.keyword, keyword.control.at-rule.mixin punctuation.definition.keyword, meta.at-rule.include keyword.control.at-rule.include, keyword.control.at-rule.extend punctuation.definition.keyword, meta.at-rule.extend keyword.control.at-rule.extend, entity.other.attribute-name.placeholder.css punctuation.definition.entity.css, meta.at-rule.media keyword.control.at-rule.media, meta.at-rule.mixin keyword.control.at-rule.mixin, meta.at-rule.function keyword.control.at-rule.function, keyword.control punctuation.definition.keyword, meta.at-rule.import.scss entity.other.attribute-name.placeholder.scss punctuation.definition.entity.scss, meta.at-rule.import.scss keyword.control.at-rule.import.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7847bd</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS Include Mixin Argument</string>
+			<key>scope</key>
+			<string>meta.property-list meta.at-rule.include</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS value</string>
+			<key>scope</key>
+			<string>support.constant.property-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b15c00</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Sub-methods</string>
+			<key>scope</key>
+			<string>entity.name.module.js, variable.import.parameter.js, variable.other.class.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Language methods</string>
+			<key>scope</key>
+			<string>variable.language</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable punctuation</string>
+			<key>scope</key>
+			<string>variable.other punctuation.definition.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword this with Punctuation, ES7 Bind Operator</string>
+			<key>scope</key>
+			<string>source.js constant.other.object.key.js string.unquoted.label.js, variable.language.this punctuation.definition.variable, keyword.other.this</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML Attributes</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name, text.html.basic entity.other.attribute-name.html, text.html.basic entity.other.attribute-name, text.blade entity.other.attribute-name.class, text.html.smarty entity.other.attribute-name.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Vue Template attributes</string>
+			<key>scope</key>
+			<string>meta.directive.vue punctuation.separator.key-value.html, meta.directive.vue entity.other.attribute-name.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Vue Template attribute separator</string>
+			<key>scope</key>
+			<string>meta.directive.vue punctuation.separator.key-value.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#006a83</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS IDs</string>
+			<key>scope</key>
+			<string>source.sass keyword.control</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2e7de9</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS pseudo selectors</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.pseudo-class, entity.other.attribute-name.pseudo-element, entity.other.attribute-name.placeholder, meta.property-list meta.property-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Inserted</string>
+			<key>scope</key>
+			<string>markup.inserted</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4197a4</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Deleted</string>
+			<key>scope</key>
+			<string>markup.deleted</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c47981</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Changed</string>
+			<key>scope</key>
+			<string>markup.changed</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#506d9c</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions</string>
+			<key>scope</key>
+			<string>string.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2e5857</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.group</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Character Class</string>
+			<key>scope</key>
+			<string>constant.other.character-class.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Character Class Set</string>
+			<key>scope</key>
+			<string>constant.other.character-class.set.regexp, punctuation.definition.character-class.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#8c6c3e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Quantifier</string>
+			<key>scope</key>
+			<string>keyword.operator.quantifier.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#006a83</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Backslash</string>
+			<key>scope</key>
+			<string>constant.character.escape.backslash</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Escape Characters</string>
+			<key>scope</key>
+			<string>constant.character.escape</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#006a83</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Decorators</string>
+			<key>scope</key>
+			<string>tag.decorator.js entity.name.tag.js, tag.decorator.js punctuation.definition.tag.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2e7de9</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Units</string>
+			<key>scope</key>
+			<string>keyword.other.unit</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 0</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2e7de9</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 1</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#07879d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 2</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#007197</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 3</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 4</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#8c6c3e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 5</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#07879d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 6</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#387068</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 7</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 8</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#587539</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - value</string>
+			<key>scope</key>
+			<string>source.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#587539</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Plain Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.list_item.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Block Punctuation</string>
+			<key>scope</key>
+			<string>meta.block, meta.brace, punctuation.definition.block, punctuation.definition.use, punctuation.definition.group.shell, punctuation.definition.class, punctuation.definition.begin.bracket, punctuation.definition.end.bracket, punctuation.definition.parameters, punctuation.definition.arguments, punctuation.definition.dictionary, punctuation.definition.array, punctuation.section</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Plain</string>
+			<key>scope</key>
+			<string>meta.jsx.children, meta.embedded.block</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML text</string>
+			<key>scope</key>
+			<string>text.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Markup Raw Inline</string>
+			<key>scope</key>
+			<string>text.html.markdown markup.inline.raw.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9854f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Markup Raw Inline Punctuation</string>
+			<key>scope</key>
+			<string>text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4E5579</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 1</string>
+			<key>scope</key>
+			<string>heading.1.markdown entity.name, heading.1.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#006a83</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 2</string>
+			<key>scope</key>
+			<string>heading.2.markdown entity.name, heading.2.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#61bdf2</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 3</string>
+			<key>scope</key>
+			<string>heading.3.markdown entity.name, heading.3.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#2e7de9</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 4</string>
+			<key>scope</key>
+			<string>heading.4.markdown entity.name, heading.4.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#6d91de</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 5</string>
+			<key>scope</key>
+			<string>heading.5.markdown entity.name, heading.5.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 6</string>
+			<key>scope</key>
+			<string>heading.6.markdown entity.name, heading.6.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#747ca1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Italic</string>
+			<key>scope</key>
+			<string>markup.italic, markup.italic punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Bold</string>
+			<key>scope</key>
+			<string>markup.bold, markup.bold punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Bold-Italic</string>
+			<key>scope</key>
+			<string>markup.bold markup.italic, markup.bold markup.italic punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold italic</string>
+				<key>foreground</key>
+				<string>#3760bf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Underline</string>
+			<key>scope</key>
+			<string>markup.underline, markup.underline punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>underline</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Blockquote</string>
+			<key>scope</key>
+			<string>markup.quote punctuation.definition.blockquote.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4e5579</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Quote</string>
+			<key>scope</key>
+			<string>markup.quote</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Link</string>
+			<key>scope</key>
+			<string>string.other.link, markup.underline.link, constant.other.reference.link.markdown, string.other.link.description.title.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#387068</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Fenced Code Block</string>
+			<key>scope</key>
+			<string>markup.fenced_code.block.markdown, markup.inline.raw.string.markdown, variable.language.fenced.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#006a83</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Separator</string>
+			<key>scope</key>
+			<string>meta.separator</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#444b6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Table</string>
+			<key>scope</key>
+			<string>markup.table</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0cefc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Info</string>
+			<key>scope</key>
+			<string>token.info-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#07879d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Warn</string>
+			<key>scope</key>
+			<string>token.warn-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffdb69</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Error</string>
+			<key>scope</key>
+			<string>token.error-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c64343</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Debug</string>
+			<key>scope</key>
+			<string>token.debug-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b267e6</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Apache Tag</string>
+			<key>scope</key>
+			<string>entity.tag.apacheconf</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f52a65</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Preprocessor</string>
+			<key>scope</key>
+			<string>meta.preprocessor</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#387068</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>ENV value</string>
+			<key>scope</key>
+			<string>source.env</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2e7de9</string>
+			</dict>
+		</dict>
+	</array>
+	<key>uuid</key>
+	<string>06f855e3-9fb7-4fb1-b790-aef06065f34e</string>
+</dict>
+</plist>
+

--- a/config/bat/themes/tokyonight/tokyonight_moon.tmTheme
+++ b/config/bat/themes/tokyonight/tokyonight_moon.tmTheme
@@ -1,0 +1,1377 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Folke Lemaitre (http://github.com/folke)</string>
+	<key>colorSpaceName</key>
+	<string>sRGB</string>
+	<key>name</key>
+	<string>TokyoNight</string>
+	<key>semanticClass</key>
+	<string>enki.theme.tokyo</string>
+	<key>settings</key>
+	<array>
+		<dict>
+			<key>settings</key>
+			<dict>
+				<key>activeGuide</key>
+				<string>#363b54</string>
+				<key>background</key>
+				<string>#222436</string>
+				<key>caret</key>
+				<string>#DBC08A</string>
+				<key>findHighlight</key>
+				<string>#ffa300</string>
+				<key>findHighlightForeground</key>
+				<string>#000000</string>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+				<key>guide</key>
+				<string>#4f4f5e40</string>
+				<key>gutterForeground</key>
+				<string>#3b415caa</string>
+				<key>inactiveSelection</key>
+				<string>#282833</string>
+				<key>invisibles</key>
+				<string>#4f4f5e</string>
+				<key>lineHighlight</key>
+				<string>#00000030</string>
+				<key>selection</key>
+				<string>#9D599D40</string>
+				<key>selectionBorder</key>
+				<string>#9D599D</string>
+				<key>shadow</key>
+				<string>#00000010</string>
+				<key>stackGuide</key>
+				<string>#4f4f5e60</string>
+				<key>tagsOptions</key>
+				<string>underline</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Italics - Comments, Storage, Keyword Flow, Vue attributes, Decorators</string>
+			<key>scope</key>
+			<string>comment, meta.var.expr storage.type, keyword.control.flow, meta.directive.vue punctuation.separator.key-value.html, meta.directive.vue entity.other.attribute-name.html, tag.decorator.js entity.name.tag.js, tag.decorator.js punctuation.definition.tag.js, storage.modifier</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment</string>
+			<key>scope</key>
+			<string>comment, comment.block.documentation, punctuation.definition.comment</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#636da6</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment Doc</string>
+			<key>scope</key>
+			<string>comment.block.documentation variable, comment.block.documentation storage, comment.block.documentation punctuation, comment.block.documentation keyword, comment.block.documentation support, comment.block.documentation markup, comment.block.documentation markup.inline.raw.string.markdown, keyword.other.phpdoc.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#636da6</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Number, Boolean, Undefined, Null</string>
+			<key>scope</key>
+			<string>variable.other.constant, punctuation.definition.constant, constant.language, constant.numeric, support.constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff966c</string>
+			</dict>
+		</dict>
+    <dict>
+      <key>name</key>
+      <string>String, Symbols, Markup Heading</string>
+      <key>scope</key>
+      <string>meta.property.lua,string.unquoted.key.lua,support.other.metaproperty.lua,support.other.metaproperty.lua,constant.other.symbol, constant.other.key, markup.heading, meta.attribute-selector</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string></string>
+        <key>foreground</key>
+        <string>#4fd6be</string>
+      </dict>
+    </dict>
+		<dict>
+			<key>name</key>
+			<string>String</string>
+			<key>scope</key>
+			<string>string</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#c3e88d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Colors</string>
+			<key>scope</key>
+			<string>constant.other.color, constant.other.color.rgb-value.hex punctuation.definition.constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Info</string>
+			<key>scope</key>
+			<string>markup.info</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+				<key>background</key>
+				<string>#203346</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Warning</string>
+			<key>scope</key>
+			<string>markup.warning</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffc777</string>
+				<key>background</key>
+				<string>#38343d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Error</string>
+			<key>scope</key>
+			<string>markup.error</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c53b53</string>
+				<key>background</key>
+				<string>#322639</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Invalid</string>
+			<key>scope</key>
+			<string>invalid, invalid.illegal</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Invalid deprecated</string>
+			<key>scope</key>
+			<string>invalid.deprecated</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Storage Type</string>
+			<key>scope</key>
+			<string>storage.type</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Storage - modifier, var, const, let</string>
+			<key>scope</key>
+			<string>meta.var.expr storage.type, storage.modifier</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#fca7ea</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Interpolation</string>
+			<key>scope</key>
+			<string>punctuation.definition.template-expression, punctuation.section.embedded</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#86e1fc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Spread</string>
+			<key>scope</key>
+			<string>keyword.operator.spread, keyword.operator.rest</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Operator, Misc</string>
+			<key>scope</key>
+			<string>keyword.operator, keyword.control.as, keyword.other, keyword.operator.bitwise.shift, punctuation, punctuation.definition.constant.markdown, punctuation.definition.string, punctuation.support.type.property-name, text.html.vue-html meta.tag, punctuation.definition.keyword, punctuation.terminator.rule, punctuation.definition.entity, punctuation.definition.tag, punctuation.separator.inheritance.php, punctuation.definition.tag.html, keyword.other.template, keyword.other.substitution, entity.name.operator, text.html.vue meta.tag.block.any.html, text.html.vue meta.tag.inline.any.html, text.html.vue meta.tag.other.html, text.html.twig meta.tag.inline.any.html, text.html.twig meta.tag.block.any.html, text.html.twig meta.tag.structure.any.html, text.html.twig meta.tag.any.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Import, Export, From, Default</string>
+			<key>scope</key>
+			<string>keyword.control.import, keyword.control.export, keyword.control.from, keyword.control.default, meta.import keyword.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#86e1fc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword</string>
+			<key>scope</key>
+			<string>keyword, keyword.control, keyword.other.important</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword SQL</string>
+			<key>scope</key>
+			<string>keyword.other.DML</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#86e1fc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword Operator Logical, Arrow, Ternary, Comparison</string>
+			<key>scope</key>
+			<string>keyword.operator.logical, storage.type.function, keyword.operator.bitwise, keyword.operator.ternary, keyword.operator.comparison, keyword.operator.relational, keyword.operator.or.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Tag</string>
+			<key>scope</key>
+			<string>entity.name.tag, entity.name.tag support.class.component, meta.tag</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Tag Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.tag, punctuation.definition.tag.html, punctuation.definition.tag.begin.html, punctuation.definition.tag.end.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ba3c97</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Blade</string>
+			<key>scope</key>
+			<string>keyword.blade, entity.name.function.blade</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#82aaff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>PHP - Embedded Tag</string>
+			<key>scope</key>
+			<string>punctuation.section.embedded.begin.php, punctuation.section.embedded.end.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Smarty - Twig tag - Blade</string>
+			<key>scope</key>
+			<string>punctuation.definition.variable.smarty, punctuation.section.embedded.begin.smarty, punctuation.section.embedded.end.smarty, meta.tag.template.value.twig, punctuation.section.tag.twig, meta.tag.expression.twig, punctuation.definition.tag.expression.twig, punctuation.definition.tag.output.twig, variable.parameter.smarty</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7DCFFF</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Smarty - Twig variable - function</string>
+			<key>scope</key>
+			<string>variable.other.property.twig, support.function.twig, meta.function-call.twig, keyword.control.twig, keyword.control.smarty, keyword.operator.other.twig, keyword.operator.comparison.twig, support.function.functions.twig, support.function.functions.twig, keyword.operator.assignment.twig, support.function.filters.twig, support.function.built-in.smarty, keyword.operator.smarty, text.blade text.html.blade custom.compiler.blade.php punctuation.section.embedded.php entity.name.tag.block.any.html, text.blade text.html.blade custom.compiler.blade.php punctuation.section.embedded.php constant.other.inline-data.html, text.blade text.html.blade custom.compiler.blade.php support.function constant.other.inline-data.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#65bcff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Globals - PHP Constants  etc</string>
+			<key>scope</key>
+			<string>constant.other.php, variable.other.global.safer, variable.other.global.safer punctuation.definition.variable, variable.other.global, variable.other.global punctuation.definition.variable, constant.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffc777</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variables</string>
+			<key>scope</key>
+			<string>variable, support.variable, string constant.other.placeholder</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Variable</string>
+			<key>scope</key>
+			<string>variable.other.object, support.module.node</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Key</string>
+			<key>scope</key>
+			<string>meta.object-literal.key, meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js, string.alias.graphql, string.unquoted.graphql, string.unquoted.alias.graphql, meta.field.declaration.ts variable.object.property</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4fd6be</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Property</string>
+			<key>scope</key>
+			<string>variable.other.property, support.variable.property, support.variable.property.dom, meta.function-call variable.other.object.property, variable.language.prototype, meta.property.object, variable.other.member</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#86e1fc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Property</string>
+			<key>scope</key>
+			<string>variable.other.object.property</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Literal Member lvl 3 (Vue Prop Validation)</string>
+			<key>scope</key>
+			<string>meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#41a6b5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>C-related Block Level Variables</string>
+			<key>scope</key>
+			<string>source.cpp meta.block variable.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Other Variable</string>
+			<key>scope</key>
+			<string>support.other.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Methods</string>
+			<key>scope</key>
+			<string>meta.class-method.js entity.name.function.js, entity.name.method.js, variable.function.constructor, keyword.other.special-method, storage.type.cs</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#82aaff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function Definition</string>
+			<key>scope</key>
+			<string>entity.name.function, meta.function-call, meta.function-call entity.name.function, variable.function, meta.definition.method entity.name.function, meta.object-literal entity.name.function</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#82aaff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function Argument</string>
+			<key>scope</key>
+			<string>variable.parameter.function.language.special, variable.parameter, meta.function.parameters punctuation.definition.variable, meta.function.parameter variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffc777</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Constant, Tag Attribute</string>
+			<key>scope</key>
+			<string>keyword.other.type.php, storage.type.php, constant.character, constant.escape, keyword.other.unit</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable Definition</string>
+			<key>scope</key>
+			<string>meta.definition.variable variable.other.constant, meta.definition.variable variable.other.readwrite, variable.other.declaration</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Inherited Class</string>
+			<key>scope</key>
+			<string>entity.other.inherited-class</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Class, Support, DOM, etc</string>
+			<key>scope</key>
+			<string>support.class, support.type, variable.other.readwrite.alias, support.orther.namespace.use.php, meta.use.php, support.other.namespace.php, support.type.sys-types, support.variable.dom, support.constant.math, support.type.object.module, support.constant.json, entity.name.namespace, meta.import.qualifier, entity.name.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Class Name</string>
+			<key>scope</key>
+			<string>entity.name</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Support Function</string>
+			<key>scope</key>
+			<string>support.function</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#65bcff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Class and Support</string>
+			<key>scope</key>
+			<string>source.css support.type.property-name, source.sass support.type.property-name, source.scss support.type.property-name, source.less support.type.property-name, source.stylus support.type.property-name, source.postcss support.type.property-name, support.type.property-name.css, support.type.vendored.property-name, support.type.map.key</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#82aaff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Font</string>
+			<key>scope</key>
+			<string>support.constant.font-name, meta.definition.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c3e88d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Class</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.class, meta.at-rule.mixin.scss entity.name.function.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c3e88d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS ID</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.id</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#fc7b7b</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Tag</string>
+			<key>scope</key>
+			<string>entity.name.tag.css, entity.name.tag.reference, entity.name.tag.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Tag Reference</string>
+			<key>scope</key>
+			<string>entity.name.tag.reference</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffc777</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Property Separator</string>
+			<key>scope</key>
+			<string>meta.property-list punctuation.separator.key-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Punctuation</string>
+			<key>scope</key>
+			<string>meta.property-list, punctuation.definition.entity.css</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffc777</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS @</string>
+			<key>scope</key>
+			<string>meta.at-rule.mixin keyword.control.at-rule.mixin, meta.at-rule.include entity.name.function.scss, meta.at-rule.include keyword.control.at-rule.include</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS Mixins, Extends, Include Keyword</string>
+			<key>scope</key>
+			<string>keyword.control.at-rule.include punctuation.definition.keyword, keyword.control.at-rule.mixin punctuation.definition.keyword, meta.at-rule.include keyword.control.at-rule.include, keyword.control.at-rule.extend punctuation.definition.keyword, meta.at-rule.extend keyword.control.at-rule.extend, entity.other.attribute-name.placeholder.css punctuation.definition.entity.css, meta.at-rule.media keyword.control.at-rule.media, meta.at-rule.mixin keyword.control.at-rule.mixin, meta.at-rule.function keyword.control.at-rule.function, keyword.control punctuation.definition.keyword, meta.at-rule.import.scss entity.other.attribute-name.placeholder.scss punctuation.definition.entity.scss, meta.at-rule.import.scss keyword.control.at-rule.import.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#fca7ea</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS Include Mixin Argument</string>
+			<key>scope</key>
+			<string>meta.property-list meta.at-rule.include</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS value</string>
+			<key>scope</key>
+			<string>support.constant.property-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff966c</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Sub-methods</string>
+			<key>scope</key>
+			<string>entity.name.module.js, variable.import.parameter.js, variable.other.class.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Language methods</string>
+			<key>scope</key>
+			<string>variable.language</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable punctuation</string>
+			<key>scope</key>
+			<string>variable.other punctuation.definition.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword this with Punctuation, ES7 Bind Operator</string>
+			<key>scope</key>
+			<string>source.js constant.other.object.key.js string.unquoted.label.js, variable.language.this punctuation.definition.variable, keyword.other.this</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML Attributes</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name, text.html.basic entity.other.attribute-name.html, text.html.basic entity.other.attribute-name, text.blade entity.other.attribute-name.class, text.html.smarty entity.other.attribute-name.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Vue Template attributes</string>
+			<key>scope</key>
+			<string>meta.directive.vue punctuation.separator.key-value.html, meta.directive.vue entity.other.attribute-name.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Vue Template attribute separator</string>
+			<key>scope</key>
+			<string>meta.directive.vue punctuation.separator.key-value.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS IDs</string>
+			<key>scope</key>
+			<string>source.sass keyword.control</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#82aaff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS pseudo selectors</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.pseudo-class, entity.other.attribute-name.pseudo-element, entity.other.attribute-name.placeholder, meta.property-list meta.property-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Inserted</string>
+			<key>scope</key>
+			<string>markup.inserted</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b8db87</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Deleted</string>
+			<key>scope</key>
+			<string>markup.deleted</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e26a75</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Changed</string>
+			<key>scope</key>
+			<string>markup.changed</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7ca1f2</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions</string>
+			<key>scope</key>
+			<string>string.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b4f9f8</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.group</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Character Class</string>
+			<key>scope</key>
+			<string>constant.other.character-class.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Character Class Set</string>
+			<key>scope</key>
+			<string>constant.other.character-class.set.regexp, punctuation.definition.character-class.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffc777</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Quantifier</string>
+			<key>scope</key>
+			<string>keyword.operator.quantifier.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Backslash</string>
+			<key>scope</key>
+			<string>constant.character.escape.backslash</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Escape Characters</string>
+			<key>scope</key>
+			<string>constant.character.escape</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Decorators</string>
+			<key>scope</key>
+			<string>tag.decorator.js entity.name.tag.js, tag.decorator.js punctuation.definition.tag.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#82aaff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Units</string>
+			<key>scope</key>
+			<string>keyword.other.unit</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 0</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#82aaff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 1</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 2</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#86e1fc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 3</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 4</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffc777</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 5</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 6</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4fd6be</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 7</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 8</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c3e88d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - value</string>
+			<key>scope</key>
+			<string>source.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c3e88d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Plain Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.list_item.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Block Punctuation</string>
+			<key>scope</key>
+			<string>meta.block, meta.brace, punctuation.definition.block, punctuation.definition.use, punctuation.definition.group.shell, punctuation.definition.class, punctuation.definition.begin.bracket, punctuation.definition.end.bracket, punctuation.definition.parameters, punctuation.definition.arguments, punctuation.definition.dictionary, punctuation.definition.array, punctuation.section</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Plain</string>
+			<key>scope</key>
+			<string>meta.jsx.children, meta.embedded.block</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML text</string>
+			<key>scope</key>
+			<string>text.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Markup Raw Inline</string>
+			<key>scope</key>
+			<string>text.html.markdown markup.inline.raw.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c099ff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Markup Raw Inline Punctuation</string>
+			<key>scope</key>
+			<string>text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4E5579</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 1</string>
+			<key>scope</key>
+			<string>heading.1.markdown entity.name, heading.1.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 2</string>
+			<key>scope</key>
+			<string>heading.2.markdown entity.name, heading.2.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#61bdf2</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 3</string>
+			<key>scope</key>
+			<string>heading.3.markdown entity.name, heading.3.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#82aaff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 4</string>
+			<key>scope</key>
+			<string>heading.4.markdown entity.name, heading.4.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#6d91de</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 5</string>
+			<key>scope</key>
+			<string>heading.5.markdown entity.name, heading.5.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 6</string>
+			<key>scope</key>
+			<string>heading.6.markdown entity.name, heading.6.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#747ca1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Italic</string>
+			<key>scope</key>
+			<string>markup.italic, markup.italic punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Bold</string>
+			<key>scope</key>
+			<string>markup.bold, markup.bold punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Bold-Italic</string>
+			<key>scope</key>
+			<string>markup.bold markup.italic, markup.bold markup.italic punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold italic</string>
+				<key>foreground</key>
+				<string>#c8d3f5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Underline</string>
+			<key>scope</key>
+			<string>markup.underline, markup.underline punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>underline</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Blockquote</string>
+			<key>scope</key>
+			<string>markup.quote punctuation.definition.blockquote.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4e5579</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Quote</string>
+			<key>scope</key>
+			<string>markup.quote</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Link</string>
+			<key>scope</key>
+			<string>string.other.link, markup.underline.link, constant.other.reference.link.markdown, string.other.link.description.title.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4fd6be</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Fenced Code Block</string>
+			<key>scope</key>
+			<string>markup.fenced_code.block.markdown, markup.inline.raw.string.markdown, variable.language.fenced.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Separator</string>
+			<key>scope</key>
+			<string>meta.separator</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#444b6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Table</string>
+			<key>scope</key>
+			<string>markup.table</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0cefc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Info</string>
+			<key>scope</key>
+			<string>token.info-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Warn</string>
+			<key>scope</key>
+			<string>token.warn-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffdb69</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Error</string>
+			<key>scope</key>
+			<string>token.error-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c53b53</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Debug</string>
+			<key>scope</key>
+			<string>token.debug-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b267e6</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Apache Tag</string>
+			<key>scope</key>
+			<string>entity.tag.apacheconf</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff757f</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Preprocessor</string>
+			<key>scope</key>
+			<string>meta.preprocessor</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4fd6be</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>ENV value</string>
+			<key>scope</key>
+			<string>source.env</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#82aaff</string>
+			</dict>
+		</dict>
+	</array>
+	<key>uuid</key>
+	<string>06f855e3-9fb7-4fb1-b790-aef06065f34e</string>
+</dict>
+</plist>
+

--- a/config/bat/themes/tokyonight/tokyonight_night.tmTheme
+++ b/config/bat/themes/tokyonight/tokyonight_night.tmTheme
@@ -1,0 +1,1377 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Folke Lemaitre (http://github.com/folke)</string>
+	<key>colorSpaceName</key>
+	<string>sRGB</string>
+	<key>name</key>
+	<string>TokyoNight</string>
+	<key>semanticClass</key>
+	<string>enki.theme.tokyo</string>
+	<key>settings</key>
+	<array>
+		<dict>
+			<key>settings</key>
+			<dict>
+				<key>activeGuide</key>
+				<string>#363b54</string>
+				<key>background</key>
+				<string>#1a1b26</string>
+				<key>caret</key>
+				<string>#DBC08A</string>
+				<key>findHighlight</key>
+				<string>#ffa300</string>
+				<key>findHighlightForeground</key>
+				<string>#000000</string>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+				<key>guide</key>
+				<string>#4f4f5e40</string>
+				<key>gutterForeground</key>
+				<string>#3b415caa</string>
+				<key>inactiveSelection</key>
+				<string>#282833</string>
+				<key>invisibles</key>
+				<string>#4f4f5e</string>
+				<key>lineHighlight</key>
+				<string>#00000030</string>
+				<key>selection</key>
+				<string>#9D599D40</string>
+				<key>selectionBorder</key>
+				<string>#9D599D</string>
+				<key>shadow</key>
+				<string>#00000010</string>
+				<key>stackGuide</key>
+				<string>#4f4f5e60</string>
+				<key>tagsOptions</key>
+				<string>underline</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Italics - Comments, Storage, Keyword Flow, Vue attributes, Decorators</string>
+			<key>scope</key>
+			<string>comment, meta.var.expr storage.type, keyword.control.flow, meta.directive.vue punctuation.separator.key-value.html, meta.directive.vue entity.other.attribute-name.html, tag.decorator.js entity.name.tag.js, tag.decorator.js punctuation.definition.tag.js, storage.modifier</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment</string>
+			<key>scope</key>
+			<string>comment, comment.block.documentation, punctuation.definition.comment</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#565f89</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment Doc</string>
+			<key>scope</key>
+			<string>comment.block.documentation variable, comment.block.documentation storage, comment.block.documentation punctuation, comment.block.documentation keyword, comment.block.documentation support, comment.block.documentation markup, comment.block.documentation markup.inline.raw.string.markdown, keyword.other.phpdoc.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#565f89</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Number, Boolean, Undefined, Null</string>
+			<key>scope</key>
+			<string>variable.other.constant, punctuation.definition.constant, constant.language, constant.numeric, support.constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff9e64</string>
+			</dict>
+		</dict>
+    <dict>
+      <key>name</key>
+      <string>String, Symbols, Markup Heading</string>
+      <key>scope</key>
+      <string>meta.property.lua,string.unquoted.key.lua,support.other.metaproperty.lua,support.other.metaproperty.lua,constant.other.symbol, constant.other.key, markup.heading, meta.attribute-selector</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string></string>
+        <key>foreground</key>
+        <string>#73daca</string>
+      </dict>
+    </dict>
+		<dict>
+			<key>name</key>
+			<string>String</string>
+			<key>scope</key>
+			<string>string</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Colors</string>
+			<key>scope</key>
+			<string>constant.other.color, constant.other.color.rgb-value.hex punctuation.definition.constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Info</string>
+			<key>scope</key>
+			<string>markup.info</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+				<key>background</key>
+				<string>#192b38</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Warning</string>
+			<key>scope</key>
+			<string>markup.warning</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+				<key>background</key>
+				<string>#2e2a2d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Error</string>
+			<key>scope</key>
+			<string>markup.error</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#db4b4b</string>
+				<key>background</key>
+				<string>#2d202a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Invalid</string>
+			<key>scope</key>
+			<string>invalid, invalid.illegal</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Invalid deprecated</string>
+			<key>scope</key>
+			<string>invalid.deprecated</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Storage Type</string>
+			<key>scope</key>
+			<string>storage.type</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Storage - modifier, var, const, let</string>
+			<key>scope</key>
+			<string>meta.var.expr storage.type, storage.modifier</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9d7cd8</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Interpolation</string>
+			<key>scope</key>
+			<string>punctuation.definition.template-expression, punctuation.section.embedded</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Spread</string>
+			<key>scope</key>
+			<string>keyword.operator.spread, keyword.operator.rest</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Operator, Misc</string>
+			<key>scope</key>
+			<string>keyword.operator, keyword.control.as, keyword.other, keyword.operator.bitwise.shift, punctuation, punctuation.definition.constant.markdown, punctuation.definition.string, punctuation.support.type.property-name, text.html.vue-html meta.tag, punctuation.definition.keyword, punctuation.terminator.rule, punctuation.definition.entity, punctuation.definition.tag, punctuation.separator.inheritance.php, punctuation.definition.tag.html, keyword.other.template, keyword.other.substitution, entity.name.operator, text.html.vue meta.tag.block.any.html, text.html.vue meta.tag.inline.any.html, text.html.vue meta.tag.other.html, text.html.twig meta.tag.inline.any.html, text.html.twig meta.tag.block.any.html, text.html.twig meta.tag.structure.any.html, text.html.twig meta.tag.any.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Import, Export, From, Default</string>
+			<key>scope</key>
+			<string>keyword.control.import, keyword.control.export, keyword.control.from, keyword.control.default, meta.import keyword.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword</string>
+			<key>scope</key>
+			<string>keyword, keyword.control, keyword.other.important</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword SQL</string>
+			<key>scope</key>
+			<string>keyword.other.DML</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword Operator Logical, Arrow, Ternary, Comparison</string>
+			<key>scope</key>
+			<string>keyword.operator.logical, storage.type.function, keyword.operator.bitwise, keyword.operator.ternary, keyword.operator.comparison, keyword.operator.relational, keyword.operator.or.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Tag</string>
+			<key>scope</key>
+			<string>entity.name.tag, entity.name.tag support.class.component, meta.tag</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Tag Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.tag, punctuation.definition.tag.html, punctuation.definition.tag.begin.html, punctuation.definition.tag.end.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ba3c97</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Blade</string>
+			<key>scope</key>
+			<string>keyword.blade, entity.name.function.blade</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>PHP - Embedded Tag</string>
+			<key>scope</key>
+			<string>punctuation.section.embedded.begin.php, punctuation.section.embedded.end.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Smarty - Twig tag - Blade</string>
+			<key>scope</key>
+			<string>punctuation.definition.variable.smarty, punctuation.section.embedded.begin.smarty, punctuation.section.embedded.end.smarty, meta.tag.template.value.twig, punctuation.section.tag.twig, meta.tag.expression.twig, punctuation.definition.tag.expression.twig, punctuation.definition.tag.output.twig, variable.parameter.smarty</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7DCFFF</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Smarty - Twig variable - function</string>
+			<key>scope</key>
+			<string>variable.other.property.twig, support.function.twig, meta.function-call.twig, keyword.control.twig, keyword.control.smarty, keyword.operator.other.twig, keyword.operator.comparison.twig, support.function.functions.twig, support.function.functions.twig, keyword.operator.assignment.twig, support.function.filters.twig, support.function.built-in.smarty, keyword.operator.smarty, text.blade text.html.blade custom.compiler.blade.php punctuation.section.embedded.php entity.name.tag.block.any.html, text.blade text.html.blade custom.compiler.blade.php punctuation.section.embedded.php constant.other.inline-data.html, text.blade text.html.blade custom.compiler.blade.php support.function constant.other.inline-data.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2ac3de</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Globals - PHP Constants  etc</string>
+			<key>scope</key>
+			<string>constant.other.php, variable.other.global.safer, variable.other.global.safer punctuation.definition.variable, variable.other.global, variable.other.global punctuation.definition.variable, constant.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variables</string>
+			<key>scope</key>
+			<string>variable, support.variable, string constant.other.placeholder</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Variable</string>
+			<key>scope</key>
+			<string>variable.other.object, support.module.node</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Key</string>
+			<key>scope</key>
+			<string>meta.object-literal.key, meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js, string.alias.graphql, string.unquoted.graphql, string.unquoted.alias.graphql, meta.field.declaration.ts variable.object.property</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#73daca</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Property</string>
+			<key>scope</key>
+			<string>variable.other.property, support.variable.property, support.variable.property.dom, meta.function-call variable.other.object.property, variable.language.prototype, meta.property.object, variable.other.member</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Property</string>
+			<key>scope</key>
+			<string>variable.other.object.property</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Literal Member lvl 3 (Vue Prop Validation)</string>
+			<key>scope</key>
+			<string>meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#41a6b5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>C-related Block Level Variables</string>
+			<key>scope</key>
+			<string>source.cpp meta.block variable.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Other Variable</string>
+			<key>scope</key>
+			<string>support.other.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Methods</string>
+			<key>scope</key>
+			<string>meta.class-method.js entity.name.function.js, entity.name.method.js, variable.function.constructor, keyword.other.special-method, storage.type.cs</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function Definition</string>
+			<key>scope</key>
+			<string>entity.name.function, meta.function-call, meta.function-call entity.name.function, variable.function, meta.definition.method entity.name.function, meta.object-literal entity.name.function</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function Argument</string>
+			<key>scope</key>
+			<string>variable.parameter.function.language.special, variable.parameter, meta.function.parameters punctuation.definition.variable, meta.function.parameter variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Constant, Tag Attribute</string>
+			<key>scope</key>
+			<string>keyword.other.type.php, storage.type.php, constant.character, constant.escape, keyword.other.unit</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable Definition</string>
+			<key>scope</key>
+			<string>meta.definition.variable variable.other.constant, meta.definition.variable variable.other.readwrite, variable.other.declaration</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Inherited Class</string>
+			<key>scope</key>
+			<string>entity.other.inherited-class</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Class, Support, DOM, etc</string>
+			<key>scope</key>
+			<string>support.class, support.type, variable.other.readwrite.alias, support.orther.namespace.use.php, meta.use.php, support.other.namespace.php, support.type.sys-types, support.variable.dom, support.constant.math, support.type.object.module, support.constant.json, entity.name.namespace, meta.import.qualifier, entity.name.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Class Name</string>
+			<key>scope</key>
+			<string>entity.name</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Support Function</string>
+			<key>scope</key>
+			<string>support.function</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2ac3de</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Class and Support</string>
+			<key>scope</key>
+			<string>source.css support.type.property-name, source.sass support.type.property-name, source.scss support.type.property-name, source.less support.type.property-name, source.stylus support.type.property-name, source.postcss support.type.property-name, support.type.property-name.css, support.type.vendored.property-name, support.type.map.key</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Font</string>
+			<key>scope</key>
+			<string>support.constant.font-name, meta.definition.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Class</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.class, meta.at-rule.mixin.scss entity.name.function.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS ID</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.id</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#fc7b7b</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Tag</string>
+			<key>scope</key>
+			<string>entity.name.tag.css, entity.name.tag.reference, entity.name.tag.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Tag Reference</string>
+			<key>scope</key>
+			<string>entity.name.tag.reference</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Property Separator</string>
+			<key>scope</key>
+			<string>meta.property-list punctuation.separator.key-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Punctuation</string>
+			<key>scope</key>
+			<string>meta.property-list, punctuation.definition.entity.css</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS @</string>
+			<key>scope</key>
+			<string>meta.at-rule.mixin keyword.control.at-rule.mixin, meta.at-rule.include entity.name.function.scss, meta.at-rule.include keyword.control.at-rule.include</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS Mixins, Extends, Include Keyword</string>
+			<key>scope</key>
+			<string>keyword.control.at-rule.include punctuation.definition.keyword, keyword.control.at-rule.mixin punctuation.definition.keyword, meta.at-rule.include keyword.control.at-rule.include, keyword.control.at-rule.extend punctuation.definition.keyword, meta.at-rule.extend keyword.control.at-rule.extend, entity.other.attribute-name.placeholder.css punctuation.definition.entity.css, meta.at-rule.media keyword.control.at-rule.media, meta.at-rule.mixin keyword.control.at-rule.mixin, meta.at-rule.function keyword.control.at-rule.function, keyword.control punctuation.definition.keyword, meta.at-rule.import.scss entity.other.attribute-name.placeholder.scss punctuation.definition.entity.scss, meta.at-rule.import.scss keyword.control.at-rule.import.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9d7cd8</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS Include Mixin Argument</string>
+			<key>scope</key>
+			<string>meta.property-list meta.at-rule.include</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS value</string>
+			<key>scope</key>
+			<string>support.constant.property-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff9e64</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Sub-methods</string>
+			<key>scope</key>
+			<string>entity.name.module.js, variable.import.parameter.js, variable.other.class.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Language methods</string>
+			<key>scope</key>
+			<string>variable.language</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable punctuation</string>
+			<key>scope</key>
+			<string>variable.other punctuation.definition.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword this with Punctuation, ES7 Bind Operator</string>
+			<key>scope</key>
+			<string>source.js constant.other.object.key.js string.unquoted.label.js, variable.language.this punctuation.definition.variable, keyword.other.this</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML Attributes</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name, text.html.basic entity.other.attribute-name.html, text.html.basic entity.other.attribute-name, text.blade entity.other.attribute-name.class, text.html.smarty entity.other.attribute-name.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Vue Template attributes</string>
+			<key>scope</key>
+			<string>meta.directive.vue punctuation.separator.key-value.html, meta.directive.vue entity.other.attribute-name.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Vue Template attribute separator</string>
+			<key>scope</key>
+			<string>meta.directive.vue punctuation.separator.key-value.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS IDs</string>
+			<key>scope</key>
+			<string>source.sass keyword.control</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS pseudo selectors</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.pseudo-class, entity.other.attribute-name.pseudo-element, entity.other.attribute-name.placeholder, meta.property-list meta.property-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Inserted</string>
+			<key>scope</key>
+			<string>markup.inserted</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#449dab</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Deleted</string>
+			<key>scope</key>
+			<string>markup.deleted</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#914c54</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Changed</string>
+			<key>scope</key>
+			<string>markup.changed</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#6183bb</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions</string>
+			<key>scope</key>
+			<string>string.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b4f9f8</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.group</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Character Class</string>
+			<key>scope</key>
+			<string>constant.other.character-class.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Character Class Set</string>
+			<key>scope</key>
+			<string>constant.other.character-class.set.regexp, punctuation.definition.character-class.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Quantifier</string>
+			<key>scope</key>
+			<string>keyword.operator.quantifier.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Backslash</string>
+			<key>scope</key>
+			<string>constant.character.escape.backslash</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Escape Characters</string>
+			<key>scope</key>
+			<string>constant.character.escape</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Decorators</string>
+			<key>scope</key>
+			<string>tag.decorator.js entity.name.tag.js, tag.decorator.js punctuation.definition.tag.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Units</string>
+			<key>scope</key>
+			<string>keyword.other.unit</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 0</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 1</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 2</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 3</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 4</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 5</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 6</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#73daca</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 7</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 8</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - value</string>
+			<key>scope</key>
+			<string>source.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Plain Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.list_item.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Block Punctuation</string>
+			<key>scope</key>
+			<string>meta.block, meta.brace, punctuation.definition.block, punctuation.definition.use, punctuation.definition.group.shell, punctuation.definition.class, punctuation.definition.begin.bracket, punctuation.definition.end.bracket, punctuation.definition.parameters, punctuation.definition.arguments, punctuation.definition.dictionary, punctuation.definition.array, punctuation.section</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Plain</string>
+			<key>scope</key>
+			<string>meta.jsx.children, meta.embedded.block</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML text</string>
+			<key>scope</key>
+			<string>text.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Markup Raw Inline</string>
+			<key>scope</key>
+			<string>text.html.markdown markup.inline.raw.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Markup Raw Inline Punctuation</string>
+			<key>scope</key>
+			<string>text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4E5579</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 1</string>
+			<key>scope</key>
+			<string>heading.1.markdown entity.name, heading.1.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 2</string>
+			<key>scope</key>
+			<string>heading.2.markdown entity.name, heading.2.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#61bdf2</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 3</string>
+			<key>scope</key>
+			<string>heading.3.markdown entity.name, heading.3.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 4</string>
+			<key>scope</key>
+			<string>heading.4.markdown entity.name, heading.4.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#6d91de</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 5</string>
+			<key>scope</key>
+			<string>heading.5.markdown entity.name, heading.5.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 6</string>
+			<key>scope</key>
+			<string>heading.6.markdown entity.name, heading.6.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#747ca1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Italic</string>
+			<key>scope</key>
+			<string>markup.italic, markup.italic punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Bold</string>
+			<key>scope</key>
+			<string>markup.bold, markup.bold punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Bold-Italic</string>
+			<key>scope</key>
+			<string>markup.bold markup.italic, markup.bold markup.italic punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold italic</string>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Underline</string>
+			<key>scope</key>
+			<string>markup.underline, markup.underline punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>underline</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Blockquote</string>
+			<key>scope</key>
+			<string>markup.quote punctuation.definition.blockquote.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4e5579</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Quote</string>
+			<key>scope</key>
+			<string>markup.quote</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Link</string>
+			<key>scope</key>
+			<string>string.other.link, markup.underline.link, constant.other.reference.link.markdown, string.other.link.description.title.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#73daca</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Fenced Code Block</string>
+			<key>scope</key>
+			<string>markup.fenced_code.block.markdown, markup.inline.raw.string.markdown, variable.language.fenced.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Separator</string>
+			<key>scope</key>
+			<string>meta.separator</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#444b6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Table</string>
+			<key>scope</key>
+			<string>markup.table</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0cefc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Info</string>
+			<key>scope</key>
+			<string>token.info-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Warn</string>
+			<key>scope</key>
+			<string>token.warn-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffdb69</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Error</string>
+			<key>scope</key>
+			<string>token.error-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#db4b4b</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Debug</string>
+			<key>scope</key>
+			<string>token.debug-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b267e6</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Apache Tag</string>
+			<key>scope</key>
+			<string>entity.tag.apacheconf</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Preprocessor</string>
+			<key>scope</key>
+			<string>meta.preprocessor</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#73daca</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>ENV value</string>
+			<key>scope</key>
+			<string>source.env</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+	</array>
+	<key>uuid</key>
+	<string>06f855e3-9fb7-4fb1-b790-aef06065f34e</string>
+</dict>
+</plist>
+

--- a/config/bat/themes/tokyonight/tokyonight_storm.tmTheme
+++ b/config/bat/themes/tokyonight/tokyonight_storm.tmTheme
@@ -1,0 +1,1377 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>author</key>
+	<string>Folke Lemaitre (http://github.com/folke)</string>
+	<key>colorSpaceName</key>
+	<string>sRGB</string>
+	<key>name</key>
+	<string>TokyoNight</string>
+	<key>semanticClass</key>
+	<string>enki.theme.tokyo</string>
+	<key>settings</key>
+	<array>
+		<dict>
+			<key>settings</key>
+			<dict>
+				<key>activeGuide</key>
+				<string>#363b54</string>
+				<key>background</key>
+				<string>#24283b</string>
+				<key>caret</key>
+				<string>#DBC08A</string>
+				<key>findHighlight</key>
+				<string>#ffa300</string>
+				<key>findHighlightForeground</key>
+				<string>#000000</string>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+				<key>guide</key>
+				<string>#4f4f5e40</string>
+				<key>gutterForeground</key>
+				<string>#3b415caa</string>
+				<key>inactiveSelection</key>
+				<string>#282833</string>
+				<key>invisibles</key>
+				<string>#4f4f5e</string>
+				<key>lineHighlight</key>
+				<string>#00000030</string>
+				<key>selection</key>
+				<string>#9D599D40</string>
+				<key>selectionBorder</key>
+				<string>#9D599D</string>
+				<key>shadow</key>
+				<string>#00000010</string>
+				<key>stackGuide</key>
+				<string>#4f4f5e60</string>
+				<key>tagsOptions</key>
+				<string>underline</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Italics - Comments, Storage, Keyword Flow, Vue attributes, Decorators</string>
+			<key>scope</key>
+			<string>comment, meta.var.expr storage.type, keyword.control.flow, meta.directive.vue punctuation.separator.key-value.html, meta.directive.vue entity.other.attribute-name.html, tag.decorator.js entity.name.tag.js, tag.decorator.js punctuation.definition.tag.js, storage.modifier</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment</string>
+			<key>scope</key>
+			<string>comment, comment.block.documentation, punctuation.definition.comment</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#565f89</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment Doc</string>
+			<key>scope</key>
+			<string>comment.block.documentation variable, comment.block.documentation storage, comment.block.documentation punctuation, comment.block.documentation keyword, comment.block.documentation support, comment.block.documentation markup, comment.block.documentation markup.inline.raw.string.markdown, keyword.other.phpdoc.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#565f89</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Number, Boolean, Undefined, Null</string>
+			<key>scope</key>
+			<string>variable.other.constant, punctuation.definition.constant, constant.language, constant.numeric, support.constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff9e64</string>
+			</dict>
+		</dict>
+    <dict>
+      <key>name</key>
+      <string>String, Symbols, Markup Heading</string>
+      <key>scope</key>
+      <string>meta.property.lua,string.unquoted.key.lua,support.other.metaproperty.lua,support.other.metaproperty.lua,constant.other.symbol, constant.other.key, markup.heading, meta.attribute-selector</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string></string>
+        <key>foreground</key>
+        <string>#73daca</string>
+      </dict>
+    </dict>
+		<dict>
+			<key>name</key>
+			<string>String</string>
+			<key>scope</key>
+			<string>string</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Colors</string>
+			<key>scope</key>
+			<string>constant.other.color, constant.other.color.rgb-value.hex punctuation.definition.constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Info</string>
+			<key>scope</key>
+			<string>markup.info</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+				<key>background</key>
+				<string>#22374b</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Warning</string>
+			<key>scope</key>
+			<string>markup.warning</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+				<key>background</key>
+				<string>#373640</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Error</string>
+			<key>scope</key>
+			<string>markup.error</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#db4b4b</string>
+				<key>background</key>
+				<string>#362c3d</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Invalid</string>
+			<key>scope</key>
+			<string>invalid, invalid.illegal</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Invalid deprecated</string>
+			<key>scope</key>
+			<string>invalid.deprecated</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Storage Type</string>
+			<key>scope</key>
+			<string>storage.type</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Storage - modifier, var, const, let</string>
+			<key>scope</key>
+			<string>meta.var.expr storage.type, storage.modifier</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9d7cd8</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Interpolation</string>
+			<key>scope</key>
+			<string>punctuation.definition.template-expression, punctuation.section.embedded</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Spread</string>
+			<key>scope</key>
+			<string>keyword.operator.spread, keyword.operator.rest</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Operator, Misc</string>
+			<key>scope</key>
+			<string>keyword.operator, keyword.control.as, keyword.other, keyword.operator.bitwise.shift, punctuation, punctuation.definition.constant.markdown, punctuation.definition.string, punctuation.support.type.property-name, text.html.vue-html meta.tag, punctuation.definition.keyword, punctuation.terminator.rule, punctuation.definition.entity, punctuation.definition.tag, punctuation.separator.inheritance.php, punctuation.definition.tag.html, keyword.other.template, keyword.other.substitution, entity.name.operator, text.html.vue meta.tag.block.any.html, text.html.vue meta.tag.inline.any.html, text.html.vue meta.tag.other.html, text.html.twig meta.tag.inline.any.html, text.html.twig meta.tag.block.any.html, text.html.twig meta.tag.structure.any.html, text.html.twig meta.tag.any.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Import, Export, From, Default</string>
+			<key>scope</key>
+			<string>keyword.control.import, keyword.control.export, keyword.control.from, keyword.control.default, meta.import keyword.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword</string>
+			<key>scope</key>
+			<string>keyword, keyword.control, keyword.other.important</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword SQL</string>
+			<key>scope</key>
+			<string>keyword.other.DML</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword Operator Logical, Arrow, Ternary, Comparison</string>
+			<key>scope</key>
+			<string>keyword.operator.logical, storage.type.function, keyword.operator.bitwise, keyword.operator.ternary, keyword.operator.comparison, keyword.operator.relational, keyword.operator.or.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Tag</string>
+			<key>scope</key>
+			<string>entity.name.tag, entity.name.tag support.class.component, meta.tag</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Tag Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.tag, punctuation.definition.tag.html, punctuation.definition.tag.begin.html, punctuation.definition.tag.end.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ba3c97</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Blade</string>
+			<key>scope</key>
+			<string>keyword.blade, entity.name.function.blade</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>PHP - Embedded Tag</string>
+			<key>scope</key>
+			<string>punctuation.section.embedded.begin.php, punctuation.section.embedded.end.php</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Smarty - Twig tag - Blade</string>
+			<key>scope</key>
+			<string>punctuation.definition.variable.smarty, punctuation.section.embedded.begin.smarty, punctuation.section.embedded.end.smarty, meta.tag.template.value.twig, punctuation.section.tag.twig, meta.tag.expression.twig, punctuation.definition.tag.expression.twig, punctuation.definition.tag.output.twig, variable.parameter.smarty</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7DCFFF</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Smarty - Twig variable - function</string>
+			<key>scope</key>
+			<string>variable.other.property.twig, support.function.twig, meta.function-call.twig, keyword.control.twig, keyword.control.smarty, keyword.operator.other.twig, keyword.operator.comparison.twig, support.function.functions.twig, support.function.functions.twig, keyword.operator.assignment.twig, support.function.filters.twig, support.function.built-in.smarty, keyword.operator.smarty, text.blade text.html.blade custom.compiler.blade.php punctuation.section.embedded.php entity.name.tag.block.any.html, text.blade text.html.blade custom.compiler.blade.php punctuation.section.embedded.php constant.other.inline-data.html, text.blade text.html.blade custom.compiler.blade.php support.function constant.other.inline-data.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2ac3de</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Globals - PHP Constants  etc</string>
+			<key>scope</key>
+			<string>constant.other.php, variable.other.global.safer, variable.other.global.safer punctuation.definition.variable, variable.other.global, variable.other.global punctuation.definition.variable, constant.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variables</string>
+			<key>scope</key>
+			<string>variable, support.variable, string constant.other.placeholder</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Variable</string>
+			<key>scope</key>
+			<string>variable.other.object, support.module.node</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Key</string>
+			<key>scope</key>
+			<string>meta.object-literal.key, meta.group.braces.curly constant.other.object.key.js string.unquoted.label.js, string.alias.graphql, string.unquoted.graphql, string.unquoted.alias.graphql, meta.field.declaration.ts variable.object.property</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#73daca</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Property</string>
+			<key>scope</key>
+			<string>variable.other.property, support.variable.property, support.variable.property.dom, meta.function-call variable.other.object.property, variable.language.prototype, meta.property.object, variable.other.member</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Property</string>
+			<key>scope</key>
+			<string>variable.other.object.property</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Object Literal Member lvl 3 (Vue Prop Validation)</string>
+			<key>scope</key>
+			<string>meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.objectliteral meta.object.member meta.object-literal.key</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#41a6b5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>C-related Block Level Variables</string>
+			<key>scope</key>
+			<string>source.cpp meta.block variable.other</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Other Variable</string>
+			<key>scope</key>
+			<string>support.other.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Methods</string>
+			<key>scope</key>
+			<string>meta.class-method.js entity.name.function.js, entity.name.method.js, variable.function.constructor, keyword.other.special-method, storage.type.cs</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function Definition</string>
+			<key>scope</key>
+			<string>entity.name.function, meta.function-call, meta.function-call entity.name.function, variable.function, meta.definition.method entity.name.function, meta.object-literal entity.name.function</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function Argument</string>
+			<key>scope</key>
+			<string>variable.parameter.function.language.special, variable.parameter, meta.function.parameters punctuation.definition.variable, meta.function.parameter variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Constant, Tag Attribute</string>
+			<key>scope</key>
+			<string>keyword.other.type.php, storage.type.php, constant.character, constant.escape, keyword.other.unit</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable Definition</string>
+			<key>scope</key>
+			<string>meta.definition.variable variable.other.constant, meta.definition.variable variable.other.readwrite, variable.other.declaration</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Inherited Class</string>
+			<key>scope</key>
+			<string>entity.other.inherited-class</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Class, Support, DOM, etc</string>
+			<key>scope</key>
+			<string>support.class, support.type, variable.other.readwrite.alias, support.orther.namespace.use.php, meta.use.php, support.other.namespace.php, support.type.sys-types, support.variable.dom, support.constant.math, support.type.object.module, support.constant.json, entity.name.namespace, meta.import.qualifier, entity.name.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Class Name</string>
+			<key>scope</key>
+			<string>entity.name</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Support Function</string>
+			<key>scope</key>
+			<string>support.function</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2ac3de</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Class and Support</string>
+			<key>scope</key>
+			<string>source.css support.type.property-name, source.sass support.type.property-name, source.scss support.type.property-name, source.less support.type.property-name, source.stylus support.type.property-name, source.postcss support.type.property-name, support.type.property-name.css, support.type.vendored.property-name, support.type.map.key</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Font</string>
+			<key>scope</key>
+			<string>support.constant.font-name, meta.definition.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Class</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.class, meta.at-rule.mixin.scss entity.name.function.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS ID</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.id</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#fc7b7b</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Tag</string>
+			<key>scope</key>
+			<string>entity.name.tag.css, entity.name.tag.reference, entity.name.tag.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Tag Reference</string>
+			<key>scope</key>
+			<string>entity.name.tag.reference</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Property Separator</string>
+			<key>scope</key>
+			<string>meta.property-list punctuation.separator.key-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Punctuation</string>
+			<key>scope</key>
+			<string>meta.property-list, punctuation.definition.entity.css</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS @</string>
+			<key>scope</key>
+			<string>meta.at-rule.mixin keyword.control.at-rule.mixin, meta.at-rule.include entity.name.function.scss, meta.at-rule.include keyword.control.at-rule.include</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS Mixins, Extends, Include Keyword</string>
+			<key>scope</key>
+			<string>keyword.control.at-rule.include punctuation.definition.keyword, keyword.control.at-rule.mixin punctuation.definition.keyword, meta.at-rule.include keyword.control.at-rule.include, keyword.control.at-rule.extend punctuation.definition.keyword, meta.at-rule.extend keyword.control.at-rule.extend, entity.other.attribute-name.placeholder.css punctuation.definition.entity.css, meta.at-rule.media keyword.control.at-rule.media, meta.at-rule.mixin keyword.control.at-rule.mixin, meta.at-rule.function keyword.control.at-rule.function, keyword.control punctuation.definition.keyword, meta.at-rule.import.scss entity.other.attribute-name.placeholder.scss punctuation.definition.entity.scss, meta.at-rule.import.scss keyword.control.at-rule.import.scss</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9d7cd8</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>SCSS Include Mixin Argument</string>
+			<key>scope</key>
+			<string>meta.property-list meta.at-rule.include</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS value</string>
+			<key>scope</key>
+			<string>support.constant.property-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff9e64</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Sub-methods</string>
+			<key>scope</key>
+			<string>entity.name.module.js, variable.import.parameter.js, variable.other.class.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Language methods</string>
+			<key>scope</key>
+			<string>variable.language</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable punctuation</string>
+			<key>scope</key>
+			<string>variable.other punctuation.definition.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword this with Punctuation, ES7 Bind Operator</string>
+			<key>scope</key>
+			<string>source.js constant.other.object.key.js string.unquoted.label.js, variable.language.this punctuation.definition.variable, keyword.other.this</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML Attributes</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name, text.html.basic entity.other.attribute-name.html, text.html.basic entity.other.attribute-name, text.blade entity.other.attribute-name.class, text.html.smarty entity.other.attribute-name.class</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Vue Template attributes</string>
+			<key>scope</key>
+			<string>meta.directive.vue punctuation.separator.key-value.html, meta.directive.vue entity.other.attribute-name.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Vue Template attribute separator</string>
+			<key>scope</key>
+			<string>meta.directive.vue punctuation.separator.key-value.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS IDs</string>
+			<key>scope</key>
+			<string>source.sass keyword.control</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS pseudo selectors</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.pseudo-class, entity.other.attribute-name.pseudo-element, entity.other.attribute-name.placeholder, meta.property-list meta.property-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Inserted</string>
+			<key>scope</key>
+			<string>markup.inserted</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#449dab</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Deleted</string>
+			<key>scope</key>
+			<string>markup.deleted</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#914c54</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Changed</string>
+			<key>scope</key>
+			<string>markup.changed</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#6183bb</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions</string>
+			<key>scope</key>
+			<string>string.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b4f9f8</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.group</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Character Class</string>
+			<key>scope</key>
+			<string>constant.other.character-class.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Character Class Set</string>
+			<key>scope</key>
+			<string>constant.other.character-class.set.regexp, punctuation.definition.character-class.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Quantifier</string>
+			<key>scope</key>
+			<string>keyword.operator.quantifier.regexp</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Regular Expressions - Backslash</string>
+			<key>scope</key>
+			<string>constant.character.escape.backslash</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Escape Characters</string>
+			<key>scope</key>
+			<string>constant.character.escape</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Decorators</string>
+			<key>scope</key>
+			<string>tag.decorator.js entity.name.tag.js, tag.decorator.js punctuation.definition.tag.js</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS Units</string>
+			<key>scope</key>
+			<string>keyword.other.unit</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 0</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 1</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 2</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7dcfff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 3</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 4</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#e0af68</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 5</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 6</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#73daca</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 7</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - Level 8</string>
+			<key>scope</key>
+			<string>source.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.value.json meta.sequence.json meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>JSON Key - value</string>
+			<key>scope</key>
+			<string>source.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json, source.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json meta.structure.array.json meta.structure.dictionary.json meta.structure.dictionary.value.json string.quoted.double.json</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9ece6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Plain Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.list_item.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Block Punctuation</string>
+			<key>scope</key>
+			<string>meta.block, meta.brace, punctuation.definition.block, punctuation.definition.use, punctuation.definition.group.shell, punctuation.definition.class, punctuation.definition.begin.bracket, punctuation.definition.end.bracket, punctuation.definition.parameters, punctuation.definition.arguments, punctuation.definition.dictionary, punctuation.definition.array, punctuation.section</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9abdf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Plain</string>
+			<key>scope</key>
+			<string>meta.jsx.children, meta.embedded.block</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML text</string>
+			<key>scope</key>
+			<string>text.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Markup Raw Inline</string>
+			<key>scope</key>
+			<string>text.html.markdown markup.inline.raw.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bb9af7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Markup Raw Inline Punctuation</string>
+			<key>scope</key>
+			<string>text.html.markdown markup.inline.raw.markdown punctuation.definition.raw.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4E5579</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 1</string>
+			<key>scope</key>
+			<string>heading.1.markdown entity.name, heading.1.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 2</string>
+			<key>scope</key>
+			<string>heading.2.markdown entity.name, heading.2.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#61bdf2</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 3</string>
+			<key>scope</key>
+			<string>heading.3.markdown entity.name, heading.3.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 4</string>
+			<key>scope</key>
+			<string>heading.4.markdown entity.name, heading.4.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#6d91de</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 5</string>
+			<key>scope</key>
+			<string>heading.5.markdown entity.name, heading.5.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#9aa5ce</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Heading 6</string>
+			<key>scope</key>
+			<string>heading.6.markdown entity.name, heading.6.markdown punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#747ca1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Italic</string>
+			<key>scope</key>
+			<string>markup.italic, markup.italic punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Bold</string>
+			<key>scope</key>
+			<string>markup.bold, markup.bold punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Bold-Italic</string>
+			<key>scope</key>
+			<string>markup.bold markup.italic, markup.bold markup.italic punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold italic</string>
+				<key>foreground</key>
+				<string>#c0caf5</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Underline</string>
+			<key>scope</key>
+			<string>markup.underline, markup.underline punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>underline</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Blockquote</string>
+			<key>scope</key>
+			<string>markup.quote punctuation.definition.blockquote.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4e5579</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Quote</string>
+			<key>scope</key>
+			<string>markup.quote</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Link</string>
+			<key>scope</key>
+			<string>string.other.link, markup.underline.link, constant.other.reference.link.markdown, string.other.link.description.title.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#73daca</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Fenced Code Block</string>
+			<key>scope</key>
+			<string>markup.fenced_code.block.markdown, markup.inline.raw.string.markdown, variable.language.fenced.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#89ddff</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown - Separator</string>
+			<key>scope</key>
+			<string>meta.separator</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+				<key>foreground</key>
+				<string>#444b6a</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup - Table</string>
+			<key>scope</key>
+			<string>markup.table</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#c0cefc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Info</string>
+			<key>scope</key>
+			<string>token.info-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#0db9d7</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Warn</string>
+			<key>scope</key>
+			<string>token.warn-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffdb69</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Error</string>
+			<key>scope</key>
+			<string>token.error-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#db4b4b</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Token - Debug</string>
+			<key>scope</key>
+			<string>token.debug-token</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b267e6</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Apache Tag</string>
+			<key>scope</key>
+			<string>entity.tag.apacheconf</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f7768e</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Preprocessor</string>
+			<key>scope</key>
+			<string>meta.preprocessor</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#73daca</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>ENV value</string>
+			<key>scope</key>
+			<string>source.env</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#7aa2f7</string>
+			</dict>
+		</dict>
+	</array>
+	<key>uuid</key>
+	<string>06f855e3-9fb7-4fb1-b790-aef06065f34e</string>
+</dict>
+</plist>
+

--- a/config/fish/themes/tokyonight_day.theme
+++ b/config/fish/themes/tokyonight_day.theme
@@ -1,1 +1,25 @@
-/home/dai/ghq/github.com/folke/tokyonight.nvim/extras/fish_themes/tokyonight_day.theme
+# TokyoNight
+
+# Syntax Highlighting Colors
+fish_color_normal 3760bf
+fish_color_command 007197
+fish_color_keyword 9854f1
+fish_color_quote 8c6c3e
+fish_color_redirection 3760bf
+fish_color_end b15c00
+fish_color_option 9854f1
+fish_color_error f52a65
+fish_color_param 7847bd
+fish_color_comment 848cb5
+fish_color_selection --background=b7c1e3
+fish_color_search_match --background=b7c1e3
+fish_color_operator 587539
+fish_color_escape 9854f1
+fish_color_autosuggestion 848cb5
+
+# Completion Pager Colors
+fish_pager_color_progress 848cb5
+fish_pager_color_prefix 007197
+fish_pager_color_completion 3760bf
+fish_pager_color_description 848cb5
+fish_pager_color_selected_background --background=b7c1e3

--- a/config/fish/themes/tokyonight_night.theme
+++ b/config/fish/themes/tokyonight_night.theme
@@ -1,1 +1,25 @@
-/home/dai/ghq/github.com/folke/tokyonight.nvim/extras/fish_themes/tokyonight_night.theme
+# TokyoNight
+
+# Syntax Highlighting Colors
+fish_color_normal c0caf5
+fish_color_command 7dcfff
+fish_color_keyword bb9af7
+fish_color_quote e0af68
+fish_color_redirection c0caf5
+fish_color_end ff9e64
+fish_color_option bb9af7
+fish_color_error f7768e
+fish_color_param 9d7cd8
+fish_color_comment 565f89
+fish_color_selection --background=283457
+fish_color_search_match --background=283457
+fish_color_operator 9ece6a
+fish_color_escape bb9af7
+fish_color_autosuggestion 565f89
+
+# Completion Pager Colors
+fish_pager_color_progress 565f89
+fish_pager_color_prefix 7dcfff
+fish_pager_color_completion c0caf5
+fish_pager_color_description 565f89
+fish_pager_color_selected_background --background=283457

--- a/config/hypr/scripts/activity-logger.sh
+++ b/config/hypr/scripts/activity-logger.sh
@@ -2,161 +2,144 @@
 # ==============================================================================
 # activity-logger.sh — stream Hyprland activity events to Telegram
 #
-# Listens on the Hyprland IPC socket2 and batches events into periodic
-# Telegram messages so you can monitor app usage and workspace activity
-# remotely without being spammed per-event.
+# Listens on Hyprland IPC socket2 and batches events into periodic Telegram
+# messages. Flushes on a timer even when idle.
 #
 # Events tracked:
-#   activewindow  → app focused (class + title, deduped)
+#   activewindow  → focused app (class + title, deduped)
 #   openwindow    → new window opened
 #   closewindow   → window closed
 #   workspace     → workspace switched
 #   fullscreen    → fullscreen toggled
+#   monitoradded  → monitor hotplugged
 #
-# Config: reads ~/.config/boot-report.env (shared with boot-report.sh)
+# Config (shared with boot-report.sh): ~/.config/boot-report.env
 #   TELEGRAM_BOT_TOKEN=...
 #   TELEGRAM_CHAT_ID=...
-#
-# Optional overrides in the same file:
-#   ACTIVITY_FLUSH_INTERVAL=300   # seconds between flushes (default: 300)
-#   ACTIVITY_MIN_EVENTS=5         # min events before sending (default: 5)
-#
-# Managed by systemd user service activity-logger.service.
+#   ACTIVITY_FLUSH_INTERVAL=300   # seconds between sends (default 300)
+#   ACTIVITY_MIN_EVENTS=3         # min events to bother sending (default 3)
 # ==============================================================================
 set -euo pipefail
 
 CONFIG_FILE="${HOME}/.config/boot-report.env"
-
-if [ ! -f "$CONFIG_FILE" ]; then
-  echo "activity-logger: $CONFIG_FILE not found — exiting." >&2
-  exit 0
-fi
+[ -f "$CONFIG_FILE" ] || { echo "activity-logger: $CONFIG_FILE not found" >&2; exit 0; }
 # shellcheck source=/dev/null
 source "$CONFIG_FILE"
-
-if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
-  echo "activity-logger: missing credentials in $CONFIG_FILE" >&2
-  exit 0
-fi
+[ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ] || {
+  echo "activity-logger: missing credentials" >&2; exit 0; }
 
 FLUSH_INTERVAL="${ACTIVITY_FLUSH_INTERVAL:-300}"
-MIN_EVENTS="${ACTIVITY_MIN_EVENTS:-5}"
+MIN_EVENTS="${ACTIVITY_MIN_EVENTS:-3}"
 HOSTNAME_STR="$(hostname)"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 tg_send() {
   curl -s -X POST \
     "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-    -d chat_id="${TELEGRAM_CHAT_ID}" \
-    -d parse_mode="HTML" \
+    -d "chat_id=${TELEGRAM_CHAT_ID}" \
+    -d "parse_mode=HTML" \
     --data-urlencode "text=$1" \
-    > /dev/null 2>&1 || true
+    >/dev/null 2>&1 || true
 }
 
 # ── Find Hyprland socket ──────────────────────────────────────────────────────
-find_socket() {
-  local sig="${HYPRLAND_INSTANCE_SIGNATURE:-}"
-  if [ -z "$sig" ]; then
-    sig=$(ls /tmp/hypr/ 2>/dev/null | head -1)
-  fi
-  [ -n "$sig" ] || { echo "activity-logger: no Hyprland instance found" >&2; exit 1; }
-  echo "/tmp/hypr/${sig}/.socket2.sock"
-}
-
-SOCKET="$(find_socket)"
+SIG="${HYPRLAND_INSTANCE_SIGNATURE:-}"
+[ -n "$SIG" ] || SIG="$(ls /tmp/hypr/ 2>/dev/null | head -1)"
+[ -n "$SIG" ] || { echo "activity-logger: no Hyprland socket found" >&2; exit 1; }
+SOCKET="/tmp/hypr/${SIG}/.socket2.sock"
 [ -S "$SOCKET" ] || { echo "activity-logger: socket not found: $SOCKET" >&2; exit 1; }
 
-# ── Batch state (files — avoids subshell scoping issues) ─────────────────────
-BATCH_FILE="$(mktemp /tmp/activity-batch.XXXXXX)"
-BATCH_START_FILE="$(mktemp /tmp/activity-start.XXXXXX)"
-date '+%H:%M:%S' > "$BATCH_START_FILE"
+# ── State — plain variables, NO subshell (use socat with fd redirect) ─────────
+BATCH=()
+BATCH_START="$(date '+%H:%M:%S')"
 LAST_FLUSH="$(date +%s)"
-LAST_APP_FILE="$(mktemp /tmp/activity-lastapp.XXXXXX)"
-
-cleanup() { rm -f "$BATCH_FILE" "$BATCH_START_FILE" "$LAST_APP_FILE"; }
-trap cleanup EXIT
-
-append_event() { printf '%s\n' "$1" >> "$BATCH_FILE"; }
+LAST_APP=""
 
 flush_batch() {
-  local count
-  count=$(wc -l < "$BATCH_FILE" 2>/dev/null || echo 0)
-
+  local count="${#BATCH[@]}"
   if [ "$count" -lt "$MIN_EVENTS" ]; then
-    # Not enough events yet — reset timer but keep batch
+    BATCH=()
+    BATCH_START="$(date '+%H:%M:%S')"
     LAST_FLUSH="$(date +%s)"
     return
   fi
 
-  local start end_time
-  start="$(cat "$BATCH_START_FILE")"
+  local end_time msg body i
   end_time="$(date '+%H:%M:%S')"
+  body=""
+  for i in "${!BATCH[@]}"; do
+    body="${body}${BATCH[$i]}"$'\n'
+  done
 
-  local header
-  header="$(printf '\xf0\x9f\x93\x8a') <b>Activity — ${HOSTNAME_STR}</b>
-<b>Period:</b> ${start} → ${end_time}  (<b>${count}</b> events)
-"
-  local body
-  body="$(cat "$BATCH_FILE")"
+  msg="📊 <b>Activity — ${HOSTNAME_STR}</b>
+<b>Period:</b> ${BATCH_START} → ${end_time}  (<b>${count}</b> events)
 
-  local msg="${header}${body}"
-  if [ "${#msg}" -gt 4000 ]; then
-    msg="${msg:0:3900}
-<i>... (truncated)</i>"
-  fi
+${body}"
+
+  [ "${#msg}" -gt 4000 ] && msg="${msg:0:3900}"$'\n<i>... (truncated)</i>'
 
   tg_send "$msg"
 
-  # Reset batch
-  > "$BATCH_FILE"
-  date '+%H:%M:%S' > "$BATCH_START_FILE"
+  BATCH=()
+  BATCH_START="$(date '+%H:%M:%S')"
   LAST_FLUSH="$(date +%s)"
+  echo "activity-logger: flushed ${count} events at ${end_time}"
 }
 
-# ── Main loop ─────────────────────────────────────────────────────────────────
-echo "activity-logger: watching $SOCKET (flush every ${FLUSH_INTERVAL}s, min ${MIN_EVENTS} events)"
-
-socat - "UNIX-CONNECT:${SOCKET}" | while IFS= read -r line; do
-  [ -n "$line" ] || continue
-
-  event="${line%%>>*}"
-  data="${line#*>>}"
-  ts="$(date '+%H:%M')"
+process_event() {
+  local line="$1"
+  local event="${line%%>>*}"
+  local data="${line#*>>}"
+  local ts; ts="$(date '+%H:%M')"
 
   case "$event" in
     activewindow)
-      class="${data%%,*}"
-      title="${data#*,}"
-      last_app="$(cat "$LAST_APP_FILE" 2>/dev/null || true)"
-      if [ -n "$class" ] && [ "$class" != "$last_app" ]; then
-        echo "$class" > "$LAST_APP_FILE"
-        append_event "${ts} $(printf '\xf0\x9f\xaa\x9f') <b>${class}</b> — ${title:0:60}"
+      local class="${data%%,*}"
+      local title="${data#*,}"
+      if [ -n "$class" ] && [ "$class" != "$LAST_APP" ]; then
+        LAST_APP="$class"
+        BATCH+=("${ts} 🪟 <b>${class}</b> — ${title:0:60}")
       fi
       ;;
     openwindow)
-      class="$(echo "$data" | cut -d',' -f3)"
-      [ -n "$class" ] && append_event "${ts} $(printf '\xe2\x9c\x9a') opened <b>${class}</b>"
+      local class; class="$(echo "$data" | cut -d',' -f3)"
+      [ -n "$class" ] && BATCH+=("${ts} ✚ opened <b>${class}</b>")
       ;;
     closewindow)
-      append_event "${ts} $(printf '\xe2\x9c\x96') window closed"
+      BATCH+=("${ts} ✖ closed a window")
       ;;
     workspace)
-      append_event "${ts} $(printf '\xf0\x9f\x93\x8b') workspace $(printf '\xe2\x86\x92') <b>${data}</b>"
+      BATCH+=("${ts} 📋 workspace → <b>${data}</b>")
       ;;
     fullscreen)
-      if [ "$data" = "1" ]; then
-        append_event "${ts} $(printf '\xe2\x9b\xb6') fullscreen on"
-      else
-        append_event "${ts} $(printf '\xe2\x9b\xb6') fullscreen off"
-      fi
+      [ "$data" = "1" ] \
+        && BATCH+=("${ts} ⛶ fullscreen on") \
+        || BATCH+=("${ts} ⛶ fullscreen off")
+      ;;
+    monitoradded)
+      BATCH+=("${ts} 🖥 monitor added: <b>${data}</b>")
       ;;
   esac
+}
 
-  # Check if flush interval elapsed
+# ── Main loop — use process substitution to avoid subshell scoping ────────────
+now=0
+echo "activity-logger: watching ${SOCKET} (flush every ${FLUSH_INTERVAL}s, min ${MIN_EVENTS} events)"
+
+# Open socat as a file descriptor so the while loop runs in the CURRENT shell
+exec 3< <(socat - "UNIX-CONNECT:${SOCKET}" 2>/dev/null)
+
+while true; do
+  # Non-blocking read with timeout = 1s so the timer can fire even when idle
+  if IFS= read -r -t 1 line <&3 2>/dev/null; then
+    [ -n "$line" ] && process_event "$line"
+  fi
+
+  # Timer: flush if interval elapsed
   now="$(date +%s)"
   if [ $((now - LAST_FLUSH)) -ge "$FLUSH_INTERVAL" ]; then
     flush_batch
   fi
 done
 
-flush_batch
+exec 3<&-

--- a/config/opencode/.gitignore
+++ b/config/opencode/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package.json
 bun.lock
+skills

--- a/config/opencode/skills
+++ b/config/opencode/skills
@@ -1,1 +1,0 @@
-/home/dai/ghq/github.com/mattpocock/skills/skills

--- a/install.sh
+++ b/install.sh
@@ -374,7 +374,9 @@ provision() {
     name="$(basename "$path")"
     case "$name" in
       .gitconfig) link "$path" "$HOME/.gitconfig" ;;   # home dotfile
-      code)       : ;;                                  # handled below
+      code)       : ;;                                  # VSCode handled below
+      systemd)    : ;;                                  # user units handled below (per-file)
+      sddm)       : ;;                                  # SDDM reads /etc, configured separately
       *)          link "$path" "$HOME/.config/$name" ;;
     esac
   done
@@ -396,6 +398,22 @@ provision() {
     bash "$REPO/config/code/profiles/restore-profiles.sh"
   else
     warn "'code' not found — open VSCode once, then run config/code/profiles/restore-profiles.sh"
+  fi
+
+  # ---- 4a. opencode skills (cloned, not symlinked — was a broken absolute symlink) ----
+  # config/opencode/skills used to be a symlink to a personal absolute path.
+  # Clone the upstream skills repo into the linked config dir instead.
+  local OPENCODE_SKILLS="$HOME/.config/opencode/skills"
+  if [ ! -d "$OPENCODE_SKILLS" ]; then
+    if git clone --depth 1 https://github.com/mattpocock/skills.git /tmp/mp-skills 2>/dev/null \
+       && [ -d /tmp/mp-skills/skills ]; then
+      cp -a /tmp/mp-skills/skills "$OPENCODE_SKILLS"
+      rm -rf /tmp/mp-skills
+      info "opencode skills cloned"
+    else
+      warn "could not clone opencode skills (non-fatal) — clone manually later if needed"
+      rm -rf /tmp/mp-skills 2>/dev/null || true
+    fi
   fi
 
   # ---- 4b. Hyprland scrolling-layout plugin (hyprscrolling via hyprpm) ----

--- a/install.sh
+++ b/install.sh
@@ -272,6 +272,14 @@ provision() {
   local GIST_URL="https://gist.githubusercontent.com/erisanh/698339687f4ef296dbf886a7dff20b1f/raw/boot-report.env"
   mkdir -p "$HOME/.config"
 
+  # SECURITY NOTE: these credentials are baked into a PUBLIC repo, so anyone
+  # can read them and control/spam this Telegram bot. They are only used for a
+  # personal boot-report bot with no access to anything sensitive. After the
+  # setup is stable, revoke this bot via @BotFather and switch to the Gist or
+  # env-var method above. Treat this token as disposable.
+  local FALLBACK_BOT_TOKEN="8969386847:AAHuYDxI05h98Bl9eOB0Azh3d4xm3wgO-NI"
+  local FALLBACK_CHAT_ID="6224920853"
+
   if [ -f "$BOOT_REPORT_ENV" ]; then
     info "boot-report.env already exists — skipping fetch."
   elif [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ]; then
@@ -280,13 +288,19 @@ provision() {
     chmod 600 "$BOOT_REPORT_ENV"
     info "Telegram credentials saved from env vars."
   else
-    info "Fetching Telegram credentials from private Gist..."
-    if curl -fsSL "$GIST_URL" -o "$BOOT_REPORT_ENV" 2>/dev/null; then
+    # Try the Gist first (lets you rotate creds without editing the repo),
+    # then fall back to the hardcoded defaults so the report ALWAYS works.
+    info "Fetching Telegram credentials from Gist (with hardcoded fallback)..."
+    if curl -fsSL --retry 3 --retry-delay 2 "$GIST_URL" -o "$BOOT_REPORT_ENV" 2>/dev/null \
+       && grep -q "TELEGRAM_BOT_TOKEN" "$BOOT_REPORT_ENV"; then
       chmod 600 "$BOOT_REPORT_ENV"
-      info "boot-report.env fetched OK."
+      info "boot-report.env fetched from Gist."
     else
-      warn "Could not fetch boot-report.env (non-fatal — no Telegram report will be sent)."
-      rm -f "$BOOT_REPORT_ENV"
+      warn "Gist fetch failed — using hardcoded fallback credentials."
+      printf "TELEGRAM_BOT_TOKEN=%s\nTELEGRAM_CHAT_ID=%s\n" \
+        "$FALLBACK_BOT_TOKEN" "$FALLBACK_CHAT_ID" > "$BOOT_REPORT_ENV"
+      chmod 600 "$BOOT_REPORT_ENV"
+      info "boot-report.env written from hardcoded fallback."
     fi
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -425,28 +425,39 @@ provision() {
   if pacman -Qq sddm >/dev/null 2>&1; then
     # System-wide SDDM config (not per-user)
     sudo mkdir -p /etc/sddm.conf.d
-    sudo tee /etc/sddm.conf.d/10-theme.conf >/dev/null <<SDDMCONF
-[Theme]
-Current=astronaut
-SDDMCONF
-    info "SDDM theme set to astronaut"
-
-    # Apply astronaut theme customizations if theme is installed
-    if [ -d /usr/share/sddm/themes/astronaut ]; then
-      sudo cp -f "$REPO/config/sddm/astronaut/theme.conf.user"         /usr/share/sddm/themes/astronaut/theme.conf.user 2>/dev/null || true
-      # Use dotfiles wallpaper as SDDM background if it exists
-      if [ -f "$REPO/assets/background.png" ]; then
-        sudo mkdir -p /usr/share/sddm/themes/astronaut/Backgrounds
-        sudo cp -f "$REPO/assets/background.png"           /usr/share/sddm/themes/astronaut/Backgrounds/background-dark.png 2>/dev/null || true
-        info "SDDM background set to dotfiles wallpaper"
-      fi
-      info "astronaut theme.conf.user applied"
-    else
-      warn "sddm-astronaut-theme not installed — run: yay -S sddm-astronaut-theme"
+    # The AUR package installs into the folder 'sddm-astronaut-theme'
+    # (NOT 'astronaut'). Using the wrong name makes SDDM silently fall
+    # back to the ugly default greeter. Detect the real folder name.
+    local THEME_DIR=""
+    if [ -d /usr/share/sddm/themes/sddm-astronaut-theme ]; then
+      THEME_DIR="sddm-astronaut-theme"
+    elif [ -d /usr/share/sddm/themes/astronaut ]; then
+      THEME_DIR="astronaut"
     fi
 
-    # Allow SDDM to read the theme directory (needs correct permissions)
-    sudo chmod 755 /usr/share/sddm/themes/astronaut 2>/dev/null || true
+    if [ -n "$THEME_DIR" ]; then
+      sudo tee /etc/sddm.conf.d/10-theme.conf >/dev/null <<SDDMCONF
+[Theme]
+Current=$THEME_DIR
+
+[General]
+# sddm-astronaut-theme needs the qt virtual keyboard input method
+InputMethod=qtvirtualkeyboard
+SDDMCONF
+      info "SDDM theme set to $THEME_DIR"
+
+      # Apply theme customizations
+      sudo cp -f "$REPO/config/sddm/astronaut/theme.conf.user"         "/usr/share/sddm/themes/$THEME_DIR/theme.conf.user" 2>/dev/null || true
+      if [ -f "$REPO/assets/background.png" ]; then
+        sudo mkdir -p "/usr/share/sddm/themes/$THEME_DIR/Backgrounds"
+        sudo cp -f "$REPO/assets/background.png"           "/usr/share/sddm/themes/$THEME_DIR/Backgrounds/background-dark.png" 2>/dev/null || true
+        info "SDDM background set to dotfiles wallpaper"
+      fi
+      sudo chmod 755 "/usr/share/sddm/themes/$THEME_DIR" 2>/dev/null || true
+    else
+      warn "sddm-astronaut-theme not installed — keeping default SDDM theme."
+      warn "Install later with: yay -S sddm-astronaut-theme"
+    fi
   fi
 
   # ---- boot-report + activity-logger systemd user services ----

--- a/pacman.txt
+++ b/pacman.txt
@@ -61,6 +61,10 @@ intel-ucode
 iwd
 journalctl-desktop-notification
 jq
+socat
+curl
+python
+pciutils
 keyd
 kvantum
 lazydocker

--- a/pacman.txt
+++ b/pacman.txt
@@ -118,6 +118,9 @@ ripgrep
 rofi
 sddm
 sddm-astronaut-theme
+qt6-svg
+qt6-virtualkeyboard
+qt6-multimedia
 shellcheck
 smartmontools
 sof-firmware
@@ -140,7 +143,6 @@ tumbler
 unzip
 usbutils
 uv
-uwsm
 vim
 visual-studio-code-bin
 vulkan-intel


### PR DESCRIPTION
## Reinstall-breaking issues found and fixed

### 1. SDDM showed the default ugly greeter
The AUR package installs into folder `sddm-astronaut-theme`, not `astronaut`. install.sh now detects the real folder name and sets `Current=` correctly, plus `InputMethod=qtvirtualkeyboard`.

### 2. Missing qt6 deps for the SDDM theme
Added `qt6-svg`, `qt6-virtualkeyboard`, `qt6-multimedia` to pacman.txt.

### 3. Blank session after login
`env.lua` explicitly does not use uwsm, but `uwsm` was installed, adding a `Hyprland (uwsm-managed)` session that bypasses `env.lua` → Wayland/Qt env vars unset → nothing loads. Removed `uwsm` from pacman.txt.

### 4. Telegram reports never sent
Missing runtime deps: added `socat`, `curl`, `python`, `pciutils` to pacman.txt (required by boot-report.sh and activity-logger.sh). Also added a hardcoded credential fallback so the report always sends even if the Gist fetch fails.

### 5. activity-logger never flushed
The `socat | while` pipe ran the loop in a subshell, so batched events and the flush timer never persisted. Rewritten with process substitution + fd redirect.

### 6. Four broken absolute symlinks
Committed symlinks pointed at `/home/dai/...` and `/home/monarch/...` and broke on any fresh clone:
- `config/fish/themes/tokyonight_{night,day}.theme` → real files from folke/tokyonight.nvim
- `config/bat/themes/tokyonight` → 4 real `.tmTheme` files
- `config/opencode/skills` → removed symlink, gitignored, cloned in install.sh during provision

### 7. install.sh symlink loop bug
The generic `*)` branch symlinked `config/systemd` and `config/sddm`, causing nested symlinks for the per-file systemd user-unit loop. Both now excluded.

## Net effect
A clean `git clone` + `bash install.sh` should now boot into a themed SDDM, log into a working Hyprland session, and deliver a Telegram boot report with hardware info.