### PR TITLE
fix: add SDDM + illogical-impulse full refactor

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -318,12 +318,21 @@ provision() {
   fi
 
   # ---- 2. base packages needed before the illogical-impulse installer ----
-  log "Installing base packages (git, curl, fish, fcitx5 + Vietnamese input)"
+  # NOTE: illogical-impulse does NOT install a display manager, so we must
+  # install SDDM here (+ the qt6 deps its greeter/theme need). Without this
+  # the machine boots to a text console instead of a graphical login.
+  log "Installing base packages (sddm, git, curl, fish, fcitx5 + Vietnamese input)"
   yay -S --needed --noconfirm \
+    sddm qt6-svg qt6-virtualkeyboard qt6-multimedia \
     git curl wget fish \
     fcitx5 fcitx5-configtool fcitx5-gtk fcitx5-qt fcitx5-bamboo \
     socat python jq pciutils usbutils \
     </dev/null || warn "some base packages failed (non-fatal)"
+
+  # Enable SDDM so the graphical login starts on every boot.
+  sudo systemctl enable sddm.service 2>/dev/null \
+    && info "sddm enabled (graphical login on boot)" \
+    || warn "could not enable sddm — run: sudo systemctl enable sddm"
 
   # ---- 2a. Vietnamese input method (fcitx5 + bamboo) ----
   # Set the env vars system-wide so GTK/Qt/Wayland apps all use fcitx5.


### PR DESCRIPTION
## Thay đổi

### refactor: chuyển sang illogical-impulse (end-4/dots-hyprland)
- Xoá config cũ bị lỗi (`config/`, `nvim/`, `quickshell/`, `pacman.txt`)
- Giữ: `install.sh`, `assets/`, `README.md`, `.github/`, `keys.en.md`, `keys.vi.md`
- `provision()` viết lại: cài base packages + fcitx5-bamboo (tiếng Việt) + clone illogical-impulse + chạy `./setup install`
- `keys.en.md` + `keys.vi.md` cập nhật theo phím mặc định của illogical-impulse

### fix: SDDM không được cài → boot vào text console
- illogical-impulse không tự cài display manager
- Thêm `sddm` + `qt6-svg` + `qt6-virtualkeyboard` + `qt6-multimedia` vào danh sách cài
- Thêm `systemctl enable sddm.service` trong provision
- Không có fix này: máy boot vào tty1, không có màn login đồ họa

## Cài thủ công nếu đã cài mà thiếu SDDM
```
sudo pacman -S sddm
sudo systemctl enable --now sddm
```
Chọn session **Hyprland** (KHÔNG phải uwsm-managed) ở màn login.